### PR TITLE
feat(preprocess | stage2-2): build minimal image preprocessing pipeline

### DIFF
--- a/configs/base.yaml
+++ b/configs/base.yaml
@@ -14,8 +14,11 @@ dataset:
   query_split: query.txt
 
 preprocess:
-  image_size: [224, 224]
-  to_grayscale: false
+  resize:
+    enabled: true
+    width: 256
+    height: 256
+  color_mode: gray
 
 feature:
   local_method: sift

--- a/docs/ai/feedback/stage2/feedback_stage2-2.md
+++ b/docs/ai/feedback/stage2/feedback_stage2-2.md
@@ -1,0 +1,75 @@
+# Issue 2.2 Feedback
+
+## Changed
+
+- `src/preprocess/basic_preprocess.py` now provides a structured `PreprocessResult` and implements input validation, resize, and `color_mode=keep|gray`.
+- `src/preprocess/__init__.py` re-exports the updated preprocess interface.
+- `configs/base.yaml` now uses the minimal preprocess config shape:
+  - `resize.enabled`
+  - `resize.width`
+  - `resize.height`
+  - `color_mode`
+- `scripts/run_pipeline.py` now prints original shape, processed shape, color mode, and resize status for the preprocess stage.
+- `src/demo/web_demo.py` was updated for minimal compatibility so the demo bridge reports preprocess shapes and steps.
+- `docs/design/pipeline_skeleton.md` was updated to reflect the preprocess stage responsibilities and supported scope.
+
+## Core Design
+
+- The preprocess output is fixed to a structured result:
+  - `image`
+  - `original_shape`
+  - `processed_shape`
+  - `color_mode`
+  - `meta`
+- The preprocess module currently supports only the minimal input-standardization steps:
+  - resize
+  - grayscale conversion
+- Basic validation now checks:
+  - the input is not `None`
+  - the input is a `numpy.ndarray`
+  - the image is not empty
+  - the shape is 2D or 3D
+  - the channel count is acceptable
+- The implementation does not add augmentation, tensor normalization, denoising, CLAHE, caching, or any Stage 3 logic.
+- The code keeps backward compatibility with the earlier config style through fallback parsing of:
+  - `image_size`
+  - `to_grayscale`
+
+## Validation
+
+Commands verified:
+
+- `python -m py_compile src/preprocess/basic_preprocess.py src/preprocess/__init__.py scripts/run_pipeline.py src/demo/web_demo.py`
+- `python scripts/run_pipeline.py`
+
+Observed preprocess result on a real sample:
+
+- `original_shape=(450, 450, 3)`
+- `processed_shape=(256, 256)`
+- `color_mode=gray`
+- `steps=['resize', 'color_mode:gray']`
+
+Observed pipeline output pattern:
+
+```text
+Loaded image with shape=(450, 450, 3)
+Preprocess stage completed for ... original_shape=(450, 450, 3) processed_shape=(256, 256) color_mode=gray resize=enabled -> (256, 256) steps=['resize', 'color_mode:gray']
+```
+
+Demo compatibility check:
+
+- `gradio` imports successfully in the current environment
+- `run_demo_bridge(...)` imports successfully
+- calling `run_demo_bridge(...)` on a local sample image returns preprocess status and 4 placeholder gallery items
+
+## Acceptance Alignment
+
+This issue now satisfies the intended scope because:
+
+- a minimal preprocess module exists
+- resize is supported
+- basic color conversion is supported
+- input format and shape checks are enforced
+- `run_pipeline.py` integrates preprocess without breaking later placeholder stages
+- the output structure is clear for the future local feature module
+- Stage 1 and Stage 2.1 behavior remain usable

--- a/docs/ai/prompt/stage2/prompt_stage2-3.md
+++ b/docs/ai/prompt/stage2/prompt_stage2-3.md
@@ -1,0 +1,375 @@
+# Codex Prompt — Issue 3.1 Implement Local Feature Extraction
+
+你正在协助实现一个课程驱动、工程化推进的 **Hybrid Image Retrieval System**。
+当前项目已经完成：
+
+* Milestone 1: System Skeleton
+* Milestone 2: Data Preparation（包括 split 机制与最小 preprocess）
+
+现在进入 **Issue 3.1 — Implement Local Feature Extraction**。
+这一阶段的目标，是把当前 pipeline skeleton 中的 **local feature extraction placeholder** 替换成**真实可运行的局部特征提取模块**，为后续关键点可视化、特征保存、特征编码与倒排检索主线打基础。
+
+---
+
+## 1. Current Project Context
+
+当前项目的主链路已经具备：
+
+**sample → image loading → preprocess → local feature extraction → save placeholder → visualize placeholder**
+
+其中：
+
+* dataset loader 已能稳定读样本
+* preprocess 已能统一输入图像
+* `LocalFeatureResult` 等接口骨架已经存在
+* `run_pipeline.py` 和 demo 已可运行
+
+本 Issue 的职责不是实现完整检索，也不是提前做编码/匹配/倒排，而是：
+
+> **先把局部特征提取本身做真。**
+
+当前阶段建议优先支持：
+
+* `SIFT`
+* `ORB`
+
+因为它们与课程主线、OpenCV 工程实现和你现有原型验证都比较对齐。
+
+---
+
+## 2. Issue Target
+
+实现 **Issue 3.1 — Implement Local Feature Extraction**
+
+目标是：
+
+1. 在主工程中实现真实局部特征提取模块；
+2. 至少支持 `SIFT` 和 `ORB`；
+3. 输出结构化的：
+
+   * `keypoints`
+   * `descriptors`
+   * `meta`
+4. 将结果保存到 `outputs/features/*.npz`
+5. 接入当前 `run_pipeline.py`
+6. 为下一步关键点可视化（Issue 3.2）提供稳定输入。
+
+---
+
+## 3. Scope Boundaries
+
+### In scope
+
+本次只做以下内容：
+
+* 在主工程中实现真实 local feature extraction
+* 支持 `SIFT`
+* 支持 `ORB`
+* 统一特征输出结构
+* 最小特征保存逻辑（`.npz`）
+* 接入当前 pipeline
+* 输出简洁统计信息
+
+### Out of scope
+
+本次 **不要实现** 以下内容：
+
+* 图像匹配
+* query-gallery 检索
+* BFMatcher / FLANN 全库匹配流程
+* RANSAC
+* 特征编码 / codebook / tf-idf
+* 倒排索引
+* 重排序
+* Web Demo 的复杂特征可视化 UI
+* 任何性能优化（多进程、批处理等）
+
+原则：
+
+> **本 Issue 只做“从图像中提取并保存局部特征”这件事。**
+
+---
+
+## 4. Required File Changes
+
+请优先在以下路径完成最小改动：
+
+### Must create or update
+
+* `src/features/local/local_feature_extractor.py`
+* `src/features/local/__init__.py`
+* `scripts/run_pipeline.py`
+
+### May create if necessary
+
+* `src/features/local/extract_local_features.py`（仅当确实有助于职责清晰）
+* `src/utils/io.py` 或同等最小工具文件（仅在保存 `.npz` 时确实需要）
+* `docs/design/pipeline_skeleton.md`（如需补充 local feature 阶段说明）
+* `configs/base.yaml`
+
+### Output location
+
+请确保最小保存逻辑使用：
+
+* `outputs/features/*.npz`
+
+不要无故扩散到很多新文件。
+本 Issue 的核心交付应尽量集中在 `local_feature_extractor.py` 与现有 pipeline 上。
+
+---
+
+## 5. Functional Requirements
+
+### 5.1 Supported algorithms
+
+至少支持两种算法：
+
+* `SIFT`
+* `ORB`
+
+要求：
+
+* 从配置中选择算法
+* 若环境不支持某算法，应给出清晰错误信息
+* 不要 silently fallback 到别的算法
+
+### 5.2 Input
+
+输入应为 preprocess 后的图像，即来自当前 `PreprocessResult.image`。
+
+要求：
+
+* 能处理 grayscale 输入
+* 若传入 3 通道图像，也应稳妥处理（必要时转换为算法需要的格式）
+* 不要依赖额外深度学习框架
+
+### 5.3 Structured output
+
+请沿用或补全当前骨架中的 `LocalFeatureResult`，建议至少包含：
+
+* `keypoints`
+* `descriptors`
+* `meta`
+
+其中：
+
+#### keypoints
+
+不要直接保存 OpenCV `KeyPoint` 对象列表作为唯一可序列化结果。
+请转换成可保存、可复用的结构，例如 `Nx2` 或更丰富的数组/列表，至少包括位置；如你认为必要，也可包含：
+
+* x
+* y
+* size
+* angle
+* response
+* octave
+* class_id
+
+#### descriptors
+
+直接保存 OpenCV 输出的 descriptor 矩阵。
+
+#### meta
+
+至少记录：
+
+* `method`
+* `num_keypoints`
+* `descriptor_shape`
+* `descriptor_dtype`
+* 其他必要说明
+
+### 5.4 Empty-result handling
+
+必须清楚处理这类情况：
+
+* 图像无有效关键点
+* descriptor 为 `None`
+
+要求：
+
+* 不要崩溃
+* 返回结构化空结果
+* `meta` 中应能看出关键点数量为 0
+
+---
+
+## 6. Saving Requirement
+
+请实现最小特征保存逻辑，将结果保存为：
+
+* `outputs/features/<sample_id_or_safe_name>.npz`
+
+保存内容建议至少包括：
+
+* `keypoints`
+* `descriptors`
+* `method`
+* `num_keypoints`
+
+要求：
+
+* 文件名要安全，不要直接使用包含路径分隔符的原始路径
+* 若你需要从 sample_id 生成安全文件名，请做最小、可解释的转换
+* 不要引入复杂数据库或缓存系统
+
+---
+
+## 7. Pipeline Integration Requirement
+
+请将真实 local feature extraction 接入当前 `scripts/run_pipeline.py`。
+
+要求：
+
+1. 从 config 读取特征提取方法
+2. 对前若干个样本执行真实特征提取
+3. 打印简洁统计，例如：
+
+   * method
+   * number of keypoints
+   * descriptor shape
+   * save path
+4. 不要打坏现有 preprocess、save placeholder 之外的主链路
+
+运行：
+
+```bash
+python scripts/run_pipeline.py
+```
+
+时，用户应能看到：
+
+* preprocess 已执行
+* local feature 已真实提取
+* 特征已保存到 `outputs/features/*.npz`
+
+---
+
+## 8. Config Requirements
+
+如有必要，请在 `configs/base.yaml` 中补充最小字段，例如：
+
+```yaml
+local_feature:
+  method: sift   # or orb
+  save: true
+  max_samples: 3
+```
+
+如果你认为还需要少量算法参数，也可以加，但必须保持最小，例如：
+
+* `nfeatures`（ORB）
+* `contrast_threshold`（SIFT）
+
+要求：
+
+* 只加入当前阶段真正需要的最少字段
+* 不要做成庞大配置树
+* 默认值要稳妥
+
+---
+
+## 9. Console Output Style
+
+输出保持简洁明确，例如：
+
+* `Local feature method: sift`
+* `Extracted 128 keypoints for sample ...`
+* `Descriptor shape=(128, 128)`
+* `Saved features to outputs/features/...npz`
+
+不要引入 logging 框架。
+不要输出大段花哨文本。
+
+---
+
+## 10. Documentation Requirement
+
+如果需要，请补充当前设计文档，说明：
+
+1. local feature 阶段职责
+2. 支持的算法
+3. `LocalFeatureResult` 的输出格式
+4. `.npz` 保存内容
+5. 当前不做哪些后续逻辑（匹配、编码、检索等）
+
+优先补已有文档，不要为了这一步再新增很多文档。
+
+---
+
+## 11. Design Constraints
+
+### 11.1 Keep it stage-correct
+
+不要把这一步扩展成图像匹配或检索。
+当前只是提取和保存局部特征。
+
+### 11.2 Respect existing skeleton
+
+优先复用当前：
+
+* `PreprocessResult`
+* `LocalFeatureResult`
+* `run_pipeline.py`
+
+不要另起一套并行 pipeline。
+
+### 11.3 Save serializable results
+
+请确保输出是后续模块可读、可保存、可视化的，而不是只能在内存里存在的 OpenCV 对象。
+
+### 11.4 Preserve demo compatibility
+
+如果 demo 需要最小兼容更新，可以做，但不要大改 UI。
+关键是不要破坏 Stage 1.4 的可运行性。
+
+---
+
+## 12. Acceptance Criteria
+
+完成后应满足：
+
+1. 已实现真实 local feature extraction 模块；
+2. 至少支持 `SIFT` 和 `ORB`；
+3. 可成功输出：
+
+   * `keypoints`
+   * `descriptors`
+4. `run_pipeline.py` 可真实调用该模块；
+5. 特征可保存到 `outputs/features/*.npz`；
+6. 遇到空特征结果时不会崩溃；
+7. 没有提前引入匹配、检索或编码逻辑；
+8. 不破坏已有 preprocess / loader / demo 能力。
+
+---
+
+## 13. Expected Output From You
+
+请直接完成代码修改，并同时提供：
+
+1. 你新增/修改了哪些文件
+2. 当前支持的局部特征算法
+3. `LocalFeatureResult` 的结构说明
+4. `.npz` 保存内容说明
+5. `run_pipeline.py` 如何接入 local feature
+6. 示例运行输出
+7. 任意你采用的最小兼容或环境假设
+8. 它如何满足 acceptance criteria
+
+---
+
+## 14. Important Non-Goals
+
+请再次注意，这个 Issue 不是：
+
+* 图像匹配实现
+* query-gallery 检索
+* 结果排序
+* 倒排索引
+* codebook / tf-idf
+* Web 前端增强
+
+它只是：
+
+> **把“局部特征提取”从 placeholder 变成主工程中的真实可运行模块，并产出标准化特征文件。**

--- a/docs/design/pipeline_skeleton.md
+++ b/docs/design/pipeline_skeleton.md
@@ -2,8 +2,9 @@
 
 ## Purpose
 
-This document defines the runnable Stage 1 pipeline skeleton for the main project.  
-The goal is to keep the call chain explicit and stable before Stage 2 data preparation and Stage 3 local feature extraction are implemented in depth.
+This document defines the runnable Stage 1 pipeline skeleton for the main project.
+The goal is to keep the call chain explicit and stable before Stage 2 data preparation
+and Stage 3 local feature extraction are implemented in depth.
 
 ## Current Stage Boundaries
 
@@ -24,7 +25,7 @@ Current non-goals:
 | Stage | Module | Responsibility | Input | Output | Status |
 | --- | --- | --- | --- | --- | --- |
 | Dataset | `src/datasets/dataset_loader.py` | Scan image directory, build sample records, load images | dataset directory, sample record | `ImageSample`, loaded image | Connected |
-| Basic Preprocess | `src/preprocess/basic_preprocess.py` | Apply minimal preprocessing or passthrough | image, preprocess config | `PreprocessResult` | Connected |
+| Basic Preprocess | `src/preprocess/basic_preprocess.py` | Validate image input and apply minimal resize or color conversion | image, preprocess config | `PreprocessResult` | Connected |
 | Local Features | `src/features/local/local_feature_extractor.py` | Define local feature extraction result structure | processed image, feature config | `LocalFeatureResult` | Placeholder interface |
 | Feature Save | `scripts/run_pipeline.py` | Reserve feature saving hook | sample, feature result, output config | no-op console placeholder | Placeholder hook |
 | Visualization | `scripts/run_pipeline.py` | Reserve keypoint visualization hook | sample, image, feature result, output config | no-op console placeholder | Placeholder hook |
@@ -54,9 +55,11 @@ Primary types and functions:
 
 Current behavior:
 
-- Defaults to passthrough
-- Optionally supports lightweight grayscale conversion when `to_grayscale` is enabled
-- Returns structured metadata including input shape, output shape and applied steps
+- Validates that the input is a non-empty OpenCV-style `numpy.ndarray`
+- Supports minimal resize through `preprocess.resize.enabled`, `width`, and `height`
+- Supports `color_mode=keep` and `color_mode=gray`
+- Returns structured metadata including original shape, processed shape, color mode and applied steps
+- Does not perform augmentation, denoising, caching or deep learning style normalization
 
 ### Local Feature Extraction
 
@@ -134,7 +137,7 @@ The current skeleton intentionally reserves the following future hook chain afte
 7. Dense global retrieval
 8. Hybrid fusion
 
-These are only reserved as hook positions in code comments and documentation.  
+These are only reserved as hook positions in code comments and documentation.
 They are not implemented in Stage 1.
 
 ## Implementation Status Summary
@@ -143,7 +146,7 @@ Already connected:
 
 - Config loading
 - Dataset loading
-- Basic preprocess stage
+- Basic preprocess stage with resize and grayscale support
 - Pipeline stage sequencing from the main script
 
 Placeholder by design:
@@ -155,7 +158,7 @@ Placeholder by design:
 
 ## Why This Skeleton Exists
 
-This skeleton is not the final system architecture.  
+This skeleton is not the final system architecture.
 Its purpose is to:
 
 - keep the main call chain runnable

--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -19,14 +19,16 @@ from src.utils import get_default_config_path, load_config
 DEFAULT_PREVIEW_COUNT = 3
 
 
+
 def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Run the stage-1 pipeline skeleton.")
+    parser = argparse.ArgumentParser(description="Run the current pipeline skeleton.")
     parser.add_argument(
         "--config",
         default=get_default_config_path(),
         help="Path to the runtime config file. Defaults to configs/base.yaml.",
     )
     return parser.parse_args()
+
 
 
 def load_runtime_config(config_path: str) -> tuple[dict[str, Any], Path]:
@@ -40,6 +42,7 @@ def load_runtime_config(config_path: str) -> tuple[dict[str, Any], Path]:
     return config, resolved_path
 
 
+
 def build_dataset_loader(config: dict[str, Any]) -> tuple[ImageDatasetLoader, Path, str]:
     dataset_config = config.get("dataset")
     if not isinstance(dataset_config, dict):
@@ -50,6 +53,7 @@ def build_dataset_loader(config: dict[str, Any]) -> tuple[ImageDatasetLoader, Pa
     split = infer_split_name(dataset_root, image_dir)
     loader = ImageDatasetLoader(root_dir=image_dir, split=split, verbose=False)
     return loader, image_dir, resolved_from
+
 
 
 def resolve_dataset_image_dir(dataset_config: dict[str, Any], dataset_root: Path) -> tuple[Path, str]:
@@ -85,6 +89,7 @@ def resolve_dataset_image_dir(dataset_config: dict[str, Any], dataset_root: Path
     )
 
 
+
 def infer_split_name(dataset_root: Path, image_dir: Path) -> str:
     train_dir = (dataset_root / "train" / "image").resolve()
     test_dir = (dataset_root / "test").resolve()
@@ -95,12 +100,14 @@ def infer_split_name(dataset_root: Path, image_dir: Path) -> str:
     return "unspecified"
 
 
+
 def print_dataset_summary(loader: ImageDatasetLoader, image_dir: Path, resolved_from: str) -> None:
     stats = loader.stats()
     print(f"Resolved dataset image directory: {image_dir} ({resolved_from})")
     print(f"Loaded {stats['total_images']} images from {image_dir}")
     print(f"Dataset split: {stats['split']}")
     print(f"Supported extensions: {', '.join(stats['supported_extensions'])}")
+
 
 
 def run_pipeline_skeleton(loader: ImageDatasetLoader, config: dict[str, Any]) -> None:
@@ -114,7 +121,7 @@ def run_pipeline_skeleton(loader: ImageDatasetLoader, config: dict[str, Any]) ->
         print(f"Sample: id={sample.sample_id} file={sample.file_name} split={sample.split}")
 
         image = loader.load_image(sample)
-        print(f"Dataset stage loaded image for {sample.file_name} shape={_shape_of(image)}")
+        print(f"Loaded image with shape={_shape_of(image)}")
 
         preprocess_result = preprocess_image(image, preprocess_config)
         print_preprocess_stage(sample, preprocess_result)
@@ -129,12 +136,20 @@ def run_pipeline_skeleton(loader: ImageDatasetLoader, config: dict[str, Any]) ->
         # -> rerank -> query expansion -> dense global retrieval -> hybrid fusion
 
 
+
 def print_preprocess_stage(sample: ImageSample, result: PreprocessResult) -> None:
+    resize_meta = result.meta.get("resize", {})
+    resize_text = "disabled"
+    if isinstance(resize_meta, dict) and resize_meta.get("enabled"):
+        resize_text = f"enabled -> ({resize_meta.get('height')}, {resize_meta.get('width')})"
+
     print(
         "Preprocess stage completed for "
-        f"{sample.file_name} output_shape={result.meta.get('output_shape')} "
-        f"steps={result.meta.get('applied_steps')}"
+        f"{sample.file_name} original_shape={result.original_shape} "
+        f"processed_shape={result.processed_shape} color_mode={result.color_mode} "
+        f"resize={resize_text} steps={result.meta.get('applied_steps')}"
     )
+
 
 
 def print_local_feature_stage(sample: ImageSample, result: LocalFeatureResult) -> None:
@@ -143,6 +158,7 @@ def print_local_feature_stage(sample: ImageSample, result: LocalFeatureResult) -
         f"{sample.file_name} method={result.meta.get('method')} "
         f"keypoints={len(result.keypoints)}"
     )
+
 
 
 def save_feature_result(
@@ -155,6 +171,7 @@ def save_feature_result(
         "Save stage placeholder executed for "
         f"{sample.file_name} target={feature_dir} descriptors={feature_result.descriptors is not None}"
     )
+
 
 
 def visualize_keypoints(
@@ -171,6 +188,7 @@ def visualize_keypoints(
     )
 
 
+
 def _require_path(value: Any, field_name: str, base_dir: Path | None = None) -> Path:
     if not isinstance(value, str) or not value.strip():
         raise ValueError(f"Config field '{field_name}' must be a non-empty path string.")
@@ -183,6 +201,7 @@ def _require_path(value: Any, field_name: str, base_dir: Path | None = None) -> 
     return path
 
 
+
 def _get_mapping(config: dict[str, Any], key: str) -> dict[str, Any]:
     value = config.get(key)
     if value is None:
@@ -192,11 +211,13 @@ def _get_mapping(config: dict[str, Any], key: str) -> dict[str, Any]:
     return value
 
 
+
 def _shape_of(image: Any) -> tuple[int, ...] | None:
     shape = getattr(image, "shape", None)
     if not isinstance(shape, tuple):
         return None
     return tuple(int(dim) for dim in shape)
+
 
 
 def main() -> int:
@@ -211,7 +232,7 @@ def main() -> int:
         run_pipeline_skeleton(loader, config)
         print("Pipeline skeleton run completed")
         return 0
-    except (FileNotFoundError, NotADirectoryError, ValueError, OSError, ImportError) as exc:
+    except (FileNotFoundError, NotADirectoryError, ValueError, OSError, ImportError, TypeError) as exc:
         print(f"Pipeline skeleton run failed: {exc}")
         return 1
 

--- a/src/demo/web_demo.py
+++ b/src/demo/web_demo.py
@@ -16,6 +16,7 @@ PROJECT_ROOT = Path(__file__).resolve().parents[2]
 PLACEHOLDER_RESULT_COUNT = 4
 
 
+
 def load_demo_config(config_path: str | None = None) -> tuple[dict[str, Any], Path]:
     resolved_path = Path(config_path or get_default_config_path()).expanduser()
     if not resolved_path.is_absolute():
@@ -24,6 +25,7 @@ def load_demo_config(config_path: str | None = None) -> tuple[dict[str, Any], Pa
         resolved_path = resolved_path.resolve()
 
     return load_config(str(resolved_path)), resolved_path
+
 
 
 def run_demo_bridge(query_image_path: str | None) -> tuple[str, list[tuple[np.ndarray, str]]]:
@@ -43,7 +45,9 @@ def run_demo_bridge(query_image_path: str | None) -> tuple[str, list[tuple[np.nd
             "### Pipeline Status",
             f"- Config loaded from `{config_path}`",
             f"- Query image loaded: `{Path(query_image_path).name}` shape={shape_of(image)}",
-            f"- Preprocess stage completed: steps={preprocess_result.meta.get('applied_steps')}",
+            f"- Preprocess stage completed: original_shape={preprocess_result.original_shape}",
+            f"- Processed image shape={preprocess_result.processed_shape} color_mode={preprocess_result.color_mode}",
+            f"- Applied preprocess steps: {preprocess_result.meta.get('applied_steps')}",
             "- Local feature stage executed as placeholder",
             f"- Placeholder method: `{feature_result.meta.get('method')}`",
             "- Top-K results below are placeholders for future retrieval outputs",
@@ -51,6 +55,7 @@ def run_demo_bridge(query_image_path: str | None) -> tuple[str, list[tuple[np.nd
         ]
     )
     return status, build_placeholder_gallery()
+
 
 
 def build_demo() -> gr.Blocks:
@@ -93,6 +98,7 @@ def build_demo() -> gr.Blocks:
     return demo
 
 
+
 def load_query_image(image_path: str | Path) -> np.ndarray:
     path = Path(image_path).expanduser().resolve()
     if not path.exists():
@@ -106,6 +112,7 @@ def load_query_image(image_path: str | Path) -> np.ndarray:
     return image
 
 
+
 def build_placeholder_gallery() -> list[tuple[np.ndarray, str]]:
     return [
         (
@@ -114,6 +121,7 @@ def build_placeholder_gallery() -> list[tuple[np.ndarray, str]]:
         )
         for index in range(PLACEHOLDER_RESULT_COUNT)
     ]
+
 
 
 def create_placeholder_card(rank: int, size: tuple[int, int] = (320, 320)) -> np.ndarray:
@@ -138,6 +146,7 @@ def create_placeholder_card(rank: int, size: tuple[int, int] = (320, 320)) -> np
     return canvas
 
 
+
 def _get_mapping(config: dict[str, Any], key: str) -> dict[str, Any]:
     value = config.get(key)
     if value is None:
@@ -145,6 +154,7 @@ def _get_mapping(config: dict[str, Any], key: str) -> dict[str, Any]:
     if not isinstance(value, dict):
         raise ValueError(f"Config section '{key}' must be a mapping.")
     return value
+
 
 
 def shape_of(image: Any) -> tuple[int, ...] | None:

--- a/src/preprocess/__init__.py
+++ b/src/preprocess/__init__.py
@@ -1,3 +1,3 @@
-from .basic_preprocess import PreprocessResult, preprocess_image
+from .basic_preprocess import PreprocessResult, SUPPORTED_COLOR_MODES, preprocess_image
 
-__all__ = ["PreprocessResult", "preprocess_image"]
+__all__ = ["PreprocessResult", "SUPPORTED_COLOR_MODES", "preprocess_image"]

--- a/src/preprocess/basic_preprocess.py
+++ b/src/preprocess/basic_preprocess.py
@@ -3,54 +3,195 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any
 
+import numpy as np
+
+
+SUPPORTED_COLOR_MODES = ("keep", "gray")
+
 
 @dataclass(slots=True)
 class PreprocessResult:
-    """Minimal structured output for the preprocess stage."""
+    """Structured output for the basic preprocess stage."""
 
-    image: Any
+    image: np.ndarray
+    original_shape: tuple[int, ...]
+    processed_shape: tuple[int, ...]
+    color_mode: str
     meta: dict[str, Any] = field(default_factory=dict)
 
 
+
 def preprocess_image(image: Any, config: dict[str, Any] | None = None) -> PreprocessResult:
-    """Run a minimal preprocess stage that defaults to passthrough."""
-    config = config or {}
-    processed_image = image
+    """Validate and minimally standardize an OpenCV image for later stages."""
+    preprocess_config = config or {}
+    validated_image = _validate_image(image)
+    resize_config = _resolve_resize_config(preprocess_config)
+    requested_color_mode = _resolve_color_mode(preprocess_config)
+
+    processed_image = validated_image
     applied_steps: list[str] = []
 
-    if bool(config.get("to_grayscale", False)) and _is_color_image(image):
-        try:
-            import cv2
-        except ImportError as exc:
-            raise ImportError(
-                "OpenCV is required for grayscale preprocessing when 'to_grayscale' is enabled."
-            ) from exc
+    if resize_config["enabled"]:
+        processed_image = _resize_image(
+            processed_image,
+            width=resize_config["width"],
+            height=resize_config["height"],
+        )
+        applied_steps.append("resize")
 
-        processed_image = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
-        applied_steps.append("to_grayscale")
-    else:
+    if requested_color_mode == "gray":
+        processed_image = _convert_to_gray(processed_image)
+        applied_steps.append("color_mode:gray")
+
+    if not applied_steps:
         applied_steps.append("passthrough")
+
+    original_shape = _shape_of(validated_image)
+    processed_shape = _shape_of(processed_image)
+    final_color_mode = "gray" if processed_image.ndim == 2 else "keep"
 
     meta: dict[str, Any] = {
         "stage": "basic_preprocess",
         "status": "ready",
         "applied_steps": applied_steps,
-        "input_shape": _shape_of(image),
-        "output_shape": _shape_of(processed_image),
+        "input_shape": original_shape,
+        "output_shape": processed_shape,
+        "requested_color_mode": requested_color_mode,
+        "resize": resize_config,
     }
-    if "image_size" in config:
-        meta["requested_image_size"] = config["image_size"]
 
-    return PreprocessResult(image=processed_image, meta=meta)
+    return PreprocessResult(
+        image=processed_image,
+        original_shape=original_shape,
+        processed_shape=processed_shape,
+        color_mode=final_color_mode,
+        meta=meta,
+    )
 
 
-def _is_color_image(image: Any) -> bool:
-    shape = getattr(image, "shape", None)
-    return isinstance(shape, tuple) and len(shape) == 3 and shape[2] >= 3
+
+def _validate_image(image: Any) -> np.ndarray:
+    if image is None:
+        raise ValueError("Preprocess input image is None.")
+    if not isinstance(image, np.ndarray):
+        raise TypeError(
+            "Preprocess input must be a numpy.ndarray returned by OpenCV, "
+            f"got {type(image).__name__}."
+        )
+    if image.size == 0:
+        raise ValueError("Preprocess input image is empty.")
+    if image.ndim not in (2, 3):
+        raise ValueError(f"Preprocess input must be 2D or 3D, got ndim={image.ndim}.")
+    if image.ndim == 3 and image.shape[2] not in (1, 3):
+        raise ValueError(
+            "Preprocess input channel count must be 1 or 3, "
+            f"got shape={tuple(int(dim) for dim in image.shape)}."
+        )
+    if any(int(dim) <= 0 for dim in image.shape):
+        raise ValueError(f"Preprocess input has invalid shape: {image.shape}.")
+    return image
 
 
-def _shape_of(image: Any) -> tuple[int, ...] | None:
-    shape = getattr(image, "shape", None)
-    if not isinstance(shape, tuple):
-        return None
-    return tuple(int(dim) for dim in shape)
+
+def _resolve_resize_config(config: dict[str, Any]) -> dict[str, Any]:
+    resize_config = config.get("resize")
+    if resize_config is None:
+        legacy_image_size = config.get("image_size")
+        if legacy_image_size is None:
+            return {"enabled": False, "width": None, "height": None, "source": "default"}
+
+        height, width = _parse_size_pair(legacy_image_size, "preprocess.image_size")
+        return {
+            "enabled": True,
+            "width": width,
+            "height": height,
+            "source": "legacy_image_size",
+        }
+
+    if not isinstance(resize_config, dict):
+        raise ValueError("Config section 'preprocess.resize' must be a mapping.")
+
+    enabled = bool(resize_config.get("enabled", False))
+    width_value = resize_config.get("width")
+    height_value = resize_config.get("height")
+
+    if not enabled:
+        return {"enabled": False, "width": None, "height": None, "source": "resize_config"}
+
+    width = _parse_positive_int(width_value, "preprocess.resize.width")
+    height = _parse_positive_int(height_value, "preprocess.resize.height")
+    return {"enabled": True, "width": width, "height": height, "source": "resize_config"}
+
+
+
+def _resolve_color_mode(config: dict[str, Any]) -> str:
+    color_mode = config.get("color_mode")
+    if color_mode is None:
+        return "gray" if bool(config.get("to_grayscale", False)) else "keep"
+
+    if not isinstance(color_mode, str):
+        raise ValueError("Config field 'preprocess.color_mode' must be a string.")
+
+    normalized = color_mode.strip().lower()
+    if normalized not in SUPPORTED_COLOR_MODES:
+        raise ValueError(
+            "Unsupported preprocess.color_mode: "
+            f"{color_mode}. Supported values: {', '.join(SUPPORTED_COLOR_MODES)}"
+        )
+    return normalized
+
+
+
+def _resize_image(image: np.ndarray, width: int, height: int) -> np.ndarray:
+    try:
+        import cv2
+    except ImportError as exc:
+        raise ImportError("OpenCV is required for resize preprocessing.") from exc
+
+    return cv2.resize(image, (width, height), interpolation=cv2.INTER_AREA)
+
+
+
+def _convert_to_gray(image: np.ndarray) -> np.ndarray:
+    if image.ndim == 2:
+        return image
+
+    if image.ndim == 3 and image.shape[2] == 1:
+        return image[:, :, 0]
+
+    try:
+        import cv2
+    except ImportError as exc:
+        raise ImportError("OpenCV is required for grayscale preprocessing.") from exc
+
+    return cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
+
+
+
+def _parse_size_pair(value: Any, field_name: str) -> tuple[int, int]:
+    if not isinstance(value, (list, tuple)) or len(value) != 2:
+        raise ValueError(f"Config field '{field_name}' must be a [height, width] pair.")
+
+    height = _parse_positive_int(value[0], f"{field_name}[0]")
+    width = _parse_positive_int(value[1], f"{field_name}[1]")
+    return height, width
+
+
+
+def _parse_positive_int(value: Any, field_name: str) -> int:
+    if isinstance(value, bool):
+        raise ValueError(f"Config field '{field_name}' must be a positive integer.")
+
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"Config field '{field_name}' must be a positive integer.") from exc
+
+    if parsed <= 0:
+        raise ValueError(f"Config field '{field_name}' must be greater than zero, got {parsed}.")
+    return parsed
+
+
+
+def _shape_of(image: np.ndarray) -> tuple[int, ...]:
+    return tuple(int(dim) for dim in image.shape)


### PR DESCRIPTION
What:
- upgrade the preprocess module to validate OpenCV image inputs and return a structured PreprocessResult
- add minimal resize and color conversion support through preprocess config and integrate the stage into run_pipeline and the demo bridge
- update the base config and pipeline design doc to reflect the current preprocessing scope and behavior

Why:
- standardize image inputs before Stage 3 local feature extraction work begins
- make preprocessing behavior explicit, configurable, and reusable without introducing a heavy image processing system
- preserve the existing Stage 1 and Stage 2.1 runnable skeleton while improving input consistency for downstream modules