### PR TITLE
feat(visualization | stage3-2): implement keypoint visualization and …

### DIFF
--- a/configs/base.yaml
+++ b/configs/base.yaml
@@ -26,6 +26,10 @@ local_feature:
   max_samples: 3
   orb_nfeatures: 500
 
+visualization:
+  enabled: true
+  save_keypoints: true
+
 output:
   feature_dir: outputs/features
   index_dir: outputs/indices

--- a/docs/ai/feedback/stage3/feedback_stage3-2.md
+++ b/docs/ai/feedback/stage3/feedback_stage3-2.md
@@ -1,0 +1,73 @@
+# Issue 3.2 Feedback
+
+## Changed
+
+- `src/visualization/keypoints.py` now implements real single-image keypoint visualization based on serialized keypoints.
+- `src/visualization/__init__.py` exports the visualization helpers.
+- `scripts/run_pipeline.py` now calls the visualization stage after local feature extraction and feature saving.
+- `configs/base.yaml` now provides a minimal `visualization` config section.
+- `docs/design/pipeline_skeleton.md` now reflects that keypoint visualization is connected and saves `.png` files.
+
+## Visualization Design
+
+The visualization stage now works directly from:
+
+- the image already available in the current pipeline
+- `LocalFeatureResult.keypoints`
+
+The implementation draws keypoints from the serialized `Nx7` array and saves a PNG figure under `outputs/figures/`.
+It does not rebuild a parallel feature-reading flow and does not depend on OpenCV `KeyPoint` objects.
+
+Key behavior:
+
+- grayscale inputs are converted to a 3-channel canvas for saving
+- each keypoint is rendered as a small circle plus center point
+- a small text label is written onto the figure with the keypoint count or provided label
+- empty keypoint arrays still produce a valid saved figure
+
+## Output Naming
+
+Saved figures follow the stable format:
+
+- `outputs/figures/keypoints_<safe_sample_name>.png`
+
+The filename is derived from `sample_id` through a minimal safe-name conversion so path separators do not leak into the filename.
+
+## Validation
+
+Commands verified:
+
+- `python -m py_compile src/visualization/keypoints.py src/visualization/__init__.py scripts/run_pipeline.py`
+- `python scripts/run_pipeline.py`
+
+Observed pipeline output pattern:
+
+- `Keypoint visualization enabled`
+- `Visualized 118 keypoints for sample ...`
+- `Saved keypoint figure to outputs/figures/keypoints_...png`
+
+Observed figure check:
+
+- a real saved figure exists under `outputs/figures/`
+- loaded figure shape is `(256, 256, 3)` for a pipeline-generated sample
+
+Observed empty-keypoint check:
+
+- saving with an empty `(0, 7)` keypoint array succeeds
+- a valid `keypoints_empty__case.png` file is created instead of crashing
+
+Demo compatibility check:
+
+- `run_demo_bridge(...)` still works after this change
+- the demo remains minimal and no UI expansion was added
+
+## Acceptance Alignment
+
+This issue now satisfies the intended Stage 3.2 scope because:
+
+- keypoint visualization is implemented as a real module
+- it works directly from the current local feature output structure
+- figures are saved to `outputs/figures/keypoints_*.png`
+- `run_pipeline.py` calls the visualization stage successfully
+- empty-keypoint cases do not crash
+- no matching, retrieval, RANSAC, or other out-of-scope logic was added

--- a/docs/ai/prompt/stage3/prompt_stage3-2.md
+++ b/docs/ai/prompt/stage3/prompt_stage3-2.md
@@ -1,0 +1,319 @@
+## Issue 3.2 — Keypoint Visualization
+
+下面这份你可以直接复制给 Codex。
+
+---
+
+# Codex Prompt — Issue 3.2 Keypoint Visualization
+
+你正在协助实现一个课程驱动、工程化推进的 **Hybrid Image Retrieval System**。
+当前项目已经完成：
+
+* Milestone 1: System Skeleton
+* Milestone 2: Data Preparation
+* Issue 3.1: Real local feature extraction with SIFT / ORB and `.npz` feature saving
+
+现在进入 **Issue 3.2 — Keypoint Visualization**。
+这一阶段的目标，是把已经真实提取出来的局部特征转换为**可展示、可检查、可用于课程演示和调试**的关键点可视化结果。
+
+---
+
+## 1. Current Project Context
+
+当前项目主链路已经具备：
+
+**sample → image loading → preprocess → local feature extraction → feature save**
+
+其中：
+
+* preprocess 已经提供统一输入
+* local feature extraction 已经真实支持 `SIFT` 和 `ORB`
+* `LocalFeatureResult` 已可提供序列化的 `keypoints` 和 `descriptors`
+* `.npz` 特征文件已落到 `outputs/features/*.npz`
+
+本 Issue 的职责不是实现匹配可视化，也不是做复杂 UI，而是：
+
+> **把单张图像上的关键点直观画出来，并保存为标准 figure 输出。**
+
+这一步既服务于课程展示，也服务于你自己检查特征提取是否合理。
+
+---
+
+## 2. Issue Target
+
+实现 **Issue 3.2 — Keypoint Visualization**
+
+目标是：
+
+1. 基于当前真实 local feature extraction 结果实现关键点可视化；
+2. 支持将关键点绘制到图像上；
+3. 将可视化结果保存到：
+
+   * `outputs/figures/keypoints_*.png`
+4. 接入当前 `run_pipeline.py`
+5. 为后续 demo 或报告展示提供基础素材。
+
+---
+
+## 3. Scope Boundaries
+
+### In scope
+
+本次只做以下内容：
+
+* 单图关键点可视化
+* 从当前提取结果中读取关键点信息
+* 生成带关键点覆盖的图像
+* 保存 `.png` 结果到 `outputs/figures/`
+* 在 pipeline 中最小接入
+* 输出简洁统计信息
+
+### Out of scope
+
+本次 **不要实现** 以下内容：
+
+* 图像匹配连线可视化
+* query-gallery 对比图
+* RANSAC 内点可视化
+* Web Demo 中复杂交互式特征显示
+* 复杂前端展示增强
+* 特征编码、检索、排序
+* 批量大规模可视化系统
+* 高级绘图风格系统
+
+原则：
+
+> **本 Issue 只做“把单张图像的关键点画出来并保存”的最小可视化模块。**
+
+---
+
+## 4. Required File Changes
+
+请优先在以下路径完成最小改动：
+
+### Must create or update
+
+* `src/visualization/keypoints.py`
+* `scripts/run_pipeline.py`
+
+### May create if necessary
+
+* `src/visualization/__init__.py`
+* `docs/design/pipeline_skeleton.md`（如需补充 visualize 阶段说明）
+* `src/demo/web_demo.py`（仅当你能以极小改动兼容展示结果时，否则不要强行改）
+
+### Output location
+
+请确保输出图像保存到：
+
+* `outputs/figures/keypoints_*.png`
+
+不要无故新增很多绘图文件。
+本 Issue 的核心交付应集中在 `keypoints.py` 与现有 pipeline 接入。
+
+---
+
+## 5. Functional Requirements
+
+### 5.1 Input source
+
+可视化应基于当前主工程已有输入：
+
+* 原始图像或 preprocess 后图像
+* `LocalFeatureResult.keypoints`
+
+优先使用当前 pipeline 内已经拿到的结果，不要另起一套读取流程。
+
+### 5.2 Visualization behavior
+
+请实现单张图像关键点绘制，要求：
+
+* 在图像上绘制关键点位置
+* 输出直观可检查
+* 对关键点较多的图像也能正常显示
+* 空关键点情况也能生成合理结果，不崩溃
+
+### 5.3 Implementation choice
+
+优先使用 OpenCV 提供的关键点绘制能力，或基于 matplotlib / OpenCV 做最小实现。
+
+如果你直接使用 OpenCV 绘制，请确保能够从当前保存的 `Nx7` 关键点数组恢复出绘制所需信息；如果恢复 `cv2.KeyPoint` 麻烦，也可以采用“只画点/圆”的最小实现，但要满足：
+
+* 能清楚看到关键点分布
+* 不依赖不可序列化对象
+* 与当前 `LocalFeatureResult.keypoints` 兼容
+
+### 5.4 Empty-feature handling
+
+如果关键点数量为 0，要求：
+
+* 不要崩溃
+* 仍可保存一张图
+* 可在输出中保留原图，或附加简洁提示
+* console 输出应明确说明 keypoints=0
+
+### 5.5 Save output
+
+请将结果保存为：
+
+* `outputs/figures/keypoints_<safe_sample_name>.png`
+
+要求：
+
+* 文件名安全
+* 与 `sample_id` 或样本名有稳定对应关系
+* 不要引入复杂命名系统
+
+---
+
+## 6. Pipeline Integration Requirement
+
+请将关键点可视化接入当前 `scripts/run_pipeline.py`。
+
+要求：
+
+1. 在 local feature extraction 之后调用 visualization
+2. 对前若干个样本执行可视化
+3. 输出简洁信息，例如：
+
+   * `Visualized 118 keypoints for sample ...`
+   * `Saved figure to outputs/figures/keypoints_xxx.png`
+4. 不要打坏现有：
+
+   * preprocess
+   * local feature extraction
+   * feature save
+
+运行：
+
+```bash
+python scripts/run_pipeline.py
+```
+
+时，用户应能看到：
+
+* 特征已提取
+* 可视化已执行
+* figure 文件已保存
+
+---
+
+## 7. Config Requirements
+
+如有必要，请在 `configs/base.yaml` 中加入最少字段，例如：
+
+```yaml
+visualization:
+  enabled: true
+  save_keypoints: true
+```
+
+如果你认为还需要极少量配置，例如是否使用 preprocess 图像作为底图，也可以加，但必须保持最小。
+
+要求：
+
+* 只增加当前阶段真正需要的字段
+* 不要扩成复杂可视化配置树
+
+---
+
+## 8. Console Output Style
+
+输出保持简洁明确，例如：
+
+* `Keypoint visualization enabled`
+* `Visualized 118 keypoints for sample sample_xxx`
+* `Saved keypoint figure to outputs/figures/keypoints_sample_xxx.png`
+
+不要引入 logging 框架。
+不要输出大段花哨文本。
+
+---
+
+## 9. Documentation Requirement
+
+如果需要，请补充当前设计文档，说明：
+
+1. keypoint visualization 阶段职责
+2. 输入输出格式
+3. 可视化基于什么数据结构
+4. 输出文件命名方式
+5. 当前不做哪些内容（匹配可视化、RANSAC、检索结果展示等）
+
+优先补已有文档，不要为了这一步新增很多文档。
+
+---
+
+## 10. Design Constraints
+
+### 10.1 Keep it stage-correct
+
+不要把这一步扩展成匹配可视化或检索展示。
+当前只是单图关键点可视化。
+
+### 10.2 Reuse current local feature outputs
+
+优先复用当前 `LocalFeatureResult.keypoints`，不要另起并行格式。
+
+### 10.3 Save usable figures
+
+输出必须是真正可打开、可检查、可放进报告/演示中的图片，而不是仅在内存中显示。
+
+### 10.4 Preserve existing skeleton and demo usability
+
+不要破坏：
+
+* `run_pipeline.py`
+* local feature extraction
+* feature saving
+* demo 的最小可运行能力
+
+如果 demo 不需要更新，就不要为了“更完整”而强行改它。
+
+---
+
+## 11. Acceptance Criteria
+
+完成后应满足：
+
+1. 已实现关键点可视化模块；
+2. 能基于当前 local feature extraction 结果绘制关键点；
+3. 能保存：
+
+   * `outputs/figures/keypoints_*.png`
+4. `run_pipeline.py` 可调用该模块并正常运行；
+5. 空关键点情况不会崩溃；
+6. 没有引入匹配、检索或其他超出阶段范围的逻辑；
+7. 不破坏已有 preprocess / loader / demo / feature save 能力。
+
+---
+
+## 12. Expected Output From You
+
+请直接完成代码修改，并同时提供：
+
+1. 你新增/修改了哪些文件
+2. 当前关键点可视化的实现方式
+3. 输入使用了哪些数据
+4. 输出文件命名与保存方式
+5. `run_pipeline.py` 如何接入 visualize
+6. 示例运行输出
+7. 任意你采用的最小兼容假设
+8. 它如何满足 acceptance criteria
+
+---
+
+## 13. Important Non-Goals
+
+请再次注意，这个 Issue 不是：
+
+* 图像匹配可视化
+* query-gallery 检索结果展示
+* RANSAC 内点图
+* Web 前端增强
+* 编码 / 倒排 / 检索系统实现
+
+它只是：
+
+> **把已经真实提取出来的关键点变成可检查、可保存、可展示的图像结果。**
+

--- a/docs/design/pipeline_skeleton.md
+++ b/docs/design/pipeline_skeleton.md
@@ -4,7 +4,8 @@
 
 This document defines the runnable pipeline skeleton for the main project.
 The goal is to keep the call chain explicit and stable while the system moves from
-Stage 1 skeleton work into Stage 2 data preparation and Stage 3 local feature extraction.
+Stage 1 skeleton work into Stage 2 data preparation and Stage 3 local feature extraction
+and visualization.
 
 ## Current Stage Boundaries
 
@@ -18,7 +19,7 @@ Current non-goals:
 - No retrieval, ranking, or reranking pipeline
 - No codebook / TF-IDF / inverted index logic
 - No query expansion or dense retrieval logic
-- No real keypoint drawing yet
+- No query-gallery comparison figures yet
 
 ## Stage Overview
 
@@ -28,7 +29,7 @@ Current non-goals:
 | Basic Preprocess | `src/preprocess/basic_preprocess.py` | Validate image input and apply minimal resize or color conversion | image, preprocess config | `PreprocessResult` | Connected |
 | Local Features | `src/features/local/local_feature_extractor.py` | Extract real local features with OpenCV and return serializable results | processed image, local feature config | `LocalFeatureResult` | Connected |
 | Feature Save | `scripts/run_pipeline.py` + `src/features/local/local_feature_extractor.py` | Save extracted features as `.npz` files | sample id, feature result, output config | `outputs/features/*.npz` | Connected |
-| Visualization | `scripts/run_pipeline.py` | Reserve keypoint visualization hook | sample, image, feature result, output config | no-op console placeholder | Placeholder hook |
+| Visualization | `src/visualization/keypoints.py` + `scripts/run_pipeline.py` | Render and save single-image keypoint overlays | sample id, processed image, keypoints, output config | `outputs/figures/keypoints_*.png` | Connected |
 
 ## Module Interfaces
 
@@ -99,16 +100,19 @@ Saved content includes at least:
 - `descriptors`
 - descriptor presence and descriptor metadata
 
-### Visualization
+### Keypoint Visualization
 
-Current interface location:
+Primary types and functions:
 
-- `visualize_keypoints(sample, image, feature_result, output_config)` in `scripts/run_pipeline.py`
+- `render_keypoint_overlay(image, keypoints, label=None)`
+- `save_keypoint_visualization(sample_id, image, keypoints, output_dir, label=None)`
 
 Current behavior:
 
-- Placeholder only
-- Prints target figure directory and placeholder status
+- draws serialized keypoints directly from the `LocalFeatureResult.keypoints` array
+- saves single-image overlays as `outputs/figures/keypoints_*.png`
+- handles empty keypoint arrays by saving a valid image with a keypoint count label
+- does not implement matching lines, RANSAC views, or retrieval result layouts
 
 ## Runnable Call Order
 
@@ -122,7 +126,7 @@ The current skeleton is executed in this order:
 6. Run `preprocess_image(...)`
 7. Run `extract_local_features(...)`
 8. Save features to `outputs/features/*.npz`
-9. Run `visualize_keypoints(...)`
+9. Save keypoint figures to `outputs/figures/keypoints_*.png`
 10. Exit cleanly
 
 Pseudo-shape:
@@ -132,12 +136,17 @@ image = loader.load_image(sample)
 preprocess_result = preprocess_image(image, preprocess_config)
 feature_result = extract_local_features(preprocess_result.image, local_feature_config)
 save_path = save_local_feature_result(sample.sample_id, feature_result, output_dir)
-visualize_keypoints(sample, preprocess_result.image, feature_result, output_config)
+figure_path = save_keypoint_visualization(
+    sample.sample_id,
+    preprocess_result.image,
+    feature_result.keypoints,
+    figure_dir,
+)
 ```
 
 ## Future Hook Positions
 
-The current skeleton intentionally reserves the following future hook chain after local feature extraction and feature saving:
+The current skeleton intentionally reserves the following future hook chain after local feature extraction, feature saving, and single-image keypoint visualization:
 
 1. Feature encoding
 2. TF-IDF representation
@@ -149,7 +158,7 @@ The current skeleton intentionally reserves the following future hook chain afte
 8. Hybrid fusion
 
 These are only reserved as hook positions in code comments and documentation.
-They are not implemented in Stage 3.1.
+They are not implemented in Stage 3.2.
 
 ## Implementation Status Summary
 
@@ -160,11 +169,12 @@ Already connected:
 - Basic preprocess stage with resize and grayscale support
 - Real local feature extraction with SIFT and ORB
 - Feature saving to `.npz`
+- Keypoint visualization saving to `.png`
 - Pipeline stage sequencing from the main script
 
 Placeholder by design:
 
-- Keypoint visualization stage
+- Query-gallery comparison visualization
 - All later retrieval modules
 
 ## Why This Skeleton Exists
@@ -174,5 +184,5 @@ Its purpose is to:
 
 - keep the main call chain runnable
 - make module boundaries explicit
-- produce reusable feature files for later stages
+- produce reusable feature files and figures for later stages
 - prevent premature implementation of matching and retrieval logic

--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -14,6 +14,7 @@ from src.datasets import ImageDatasetLoader, ImageSample
 from src.features.local import LocalFeatureResult, extract_local_features, save_local_feature_result
 from src.preprocess import PreprocessResult, preprocess_image
 from src.utils import get_default_config_path, load_config
+from src.visualization import save_keypoint_visualization
 
 
 DEFAULT_PREVIEW_COUNT = 3
@@ -113,12 +114,15 @@ def print_dataset_summary(loader: ImageDatasetLoader, image_dir: Path, resolved_
 def run_pipeline_skeleton(loader: ImageDatasetLoader, config: dict[str, Any]) -> None:
     preprocess_config = _get_mapping(config, "preprocess")
     local_feature_config = _get_local_feature_config(config)
+    visualization_config = _get_visualization_config(config)
     output_config = _get_mapping(config, "output")
     sample_limit = min(_resolve_max_samples(local_feature_config), len(loader))
     samples = loader.preview(sample_limit)
 
     print(f"Running pipeline skeleton on first {len(samples)} samples")
     print(f"Local feature method: {str(local_feature_config.get('method', local_feature_config.get('local_method', 'sift'))).lower()}")
+    if bool(visualization_config.get("enabled", True)) and bool(visualization_config.get("save_keypoints", True)):
+        print("Keypoint visualization enabled")
 
     for sample in samples:
         print(f"Sample: id={sample.sample_id} file={sample.file_name} split={sample.split}")
@@ -133,10 +137,21 @@ def run_pipeline_skeleton(loader: ImageDatasetLoader, config: dict[str, Any]) ->
         print_local_feature_stage(sample, feature_result)
 
         save_path = save_feature_result(sample, feature_result, local_feature_config, output_config)
-        visualize_keypoints(sample, preprocess_result.image, feature_result, output_config)
+        figure_path = visualize_keypoints(
+            sample,
+            preprocess_result.image,
+            feature_result,
+            output_config,
+            visualization_config,
+        )
 
         if save_path is not None:
             print(f"Saved features to {save_path}")
+        if figure_path is not None:
+            print(
+                f"Visualized {feature_result.meta.get('num_keypoints')} keypoints for sample {sample.sample_id}"
+            )
+            print(f"Saved keypoint figure to {figure_path}")
 
         # Future hooks: feature encoding -> tf-idf -> inverted index -> retrieval
         # -> rerank -> query expansion -> dense global retrieval -> hybrid fusion
@@ -189,12 +204,21 @@ def visualize_keypoints(
     image: Any,
     feature_result: LocalFeatureResult,
     output_config: dict[str, Any],
-) -> None:
+    visualization_config: dict[str, Any],
+) -> Path | None:
+    enabled = bool(visualization_config.get("enabled", True))
+    save_keypoints = bool(visualization_config.get("save_keypoints", True))
+    if not enabled or not save_keypoints:
+        return None
+
     figure_dir = output_config.get("figure_dir", "outputs/figures")
-    print(
-        "Visualization stage placeholder executed for "
-        f"{sample.file_name} target={figure_dir} input_shape={_shape_of(image)} "
-        f"keypoints={feature_result.meta.get('num_keypoints')}"
+    label = f"{feature_result.meta.get('method')} keypoints={feature_result.meta.get('num_keypoints')}"
+    return save_keypoint_visualization(
+        sample.sample_id,
+        image,
+        feature_result.keypoints,
+        figure_dir,
+        label=label,
     )
 
 
@@ -212,6 +236,16 @@ def _get_local_feature_config(config: dict[str, Any]) -> dict[str, Any]:
     if not isinstance(legacy_value, dict):
         raise ValueError("Config section 'feature' must be a mapping.")
     return legacy_value
+
+
+
+def _get_visualization_config(config: dict[str, Any]) -> dict[str, Any]:
+    value = config.get("visualization")
+    if value is None:
+        return {}
+    if not isinstance(value, dict):
+        raise ValueError("Config section 'visualization' must be a mapping.")
+    return value
 
 
 

--- a/src/visualization/__init__.py
+++ b/src/visualization/__init__.py
@@ -1,0 +1,3 @@
+from .keypoints import render_keypoint_overlay, save_keypoint_visualization
+
+__all__ = ["render_keypoint_overlay", "save_keypoint_visualization"]

--- a/src/visualization/keypoints.py
+++ b/src/visualization/keypoints.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+import cv2
+import numpy as np
+
+
+
+def render_keypoint_overlay(
+    image: Any,
+    keypoints: Any,
+    label: str | None = None,
+) -> np.ndarray:
+    """Render serialized keypoints on top of an image."""
+    canvas = _prepare_canvas(image)
+    keypoint_array = _validate_keypoints(keypoints)
+
+    for keypoint in keypoint_array:
+        x = int(round(float(keypoint[0])))
+        y = int(round(float(keypoint[1])))
+        size = float(keypoint[2]) if keypoint.shape[0] >= 3 else 0.0
+        radius = max(2, int(round(size / 6.0))) if size > 0 else 2
+        cv2.circle(canvas, (x, y), radius, (0, 255, 0), 1, lineType=cv2.LINE_AA)
+        cv2.circle(canvas, (x, y), 1, (0, 0, 255), -1, lineType=cv2.LINE_AA)
+
+    overlay_label = label or f"keypoints={keypoint_array.shape[0]}"
+    cv2.putText(
+        canvas,
+        overlay_label,
+        (10, 24),
+        cv2.FONT_HERSHEY_SIMPLEX,
+        0.6,
+        (40, 40, 40),
+        2,
+        lineType=cv2.LINE_AA,
+    )
+    return canvas
+
+
+
+def save_keypoint_visualization(
+    sample_id: str,
+    image: Any,
+    keypoints: Any,
+    output_dir: str | Path,
+    label: str | None = None,
+) -> Path:
+    """Save a rendered keypoint overlay as a PNG figure."""
+    target_dir = Path(output_dir).expanduser().resolve()
+    target_dir.mkdir(parents=True, exist_ok=True)
+
+    figure = render_keypoint_overlay(image, keypoints, label=label)
+    save_path = target_dir / f"keypoints_{_make_safe_name(sample_id)}.png"
+    success = cv2.imwrite(str(save_path), figure)
+    if not success:
+        raise OSError(f"Failed to save keypoint visualization: {save_path}")
+    return save_path
+
+
+
+def _prepare_canvas(image: Any) -> np.ndarray:
+    if image is None:
+        raise ValueError("Visualization input image is None.")
+    if not isinstance(image, np.ndarray):
+        raise TypeError(
+            "Visualization input must be a numpy.ndarray, "
+            f"got {type(image).__name__}."
+        )
+    if image.size == 0:
+        raise ValueError("Visualization input image is empty.")
+    if image.ndim == 2:
+        return cv2.cvtColor(image, cv2.COLOR_GRAY2BGR)
+    if image.ndim == 3 and image.shape[2] == 1:
+        return cv2.cvtColor(image[:, :, 0], cv2.COLOR_GRAY2BGR)
+    if image.ndim == 3 and image.shape[2] == 3:
+        return image.copy()
+    raise ValueError(
+        "Visualization input image must be 2D grayscale or 3-channel BGR, "
+        f"got shape={tuple(int(dim) for dim in image.shape)}."
+    )
+
+
+
+def _validate_keypoints(keypoints: Any) -> np.ndarray:
+    if keypoints is None:
+        return np.empty((0, 2), dtype=np.float32)
+
+    keypoint_array = np.asarray(keypoints, dtype=np.float32)
+    if keypoint_array.size == 0:
+        return np.empty((0, 2), dtype=np.float32)
+    if keypoint_array.ndim != 2:
+        raise ValueError(
+            "Serialized keypoints for visualization must be a 2D array, "
+            f"got ndim={keypoint_array.ndim}."
+        )
+    if keypoint_array.shape[1] < 2:
+        raise ValueError(
+            "Serialized keypoints for visualization must provide at least x and y columns, "
+            f"got shape={keypoint_array.shape}."
+        )
+    return keypoint_array
+
+
+
+def _make_safe_name(sample_id: str) -> str:
+    normalized = str(sample_id).replace("\\", "/")
+    normalized = re.sub(r"[^A-Za-z0-9._-]+", "__", normalized)
+    normalized = normalized.strip("._")
+    return normalized or "sample"


### PR DESCRIPTION
…figure saving

What:
- add a minimal keypoint visualization module that renders serialized local feature keypoints onto single images
- integrate keypoint figure generation into run_pipeline and save figures as PNG files under outputs/figures
- update the base config, pipeline design doc, and stage feedback to reflect the connected visualization stage

Why:
- make extracted local features directly inspectable for coursework presentation, debugging, and reporting
- provide stable visual outputs that align with the current preprocess and local feature pipeline without introducing matching or retrieval logic
- preserve the existing skeleton and demo usability while turning the visualization stage from a placeholder into a real saved artifact