### PR TITLE
feat(encoding | stage4-2): add descriptor sampling and reusable codebook training

### DIFF
--- a/configs/base.yaml
+++ b/configs/base.yaml
@@ -30,6 +30,19 @@ visualization:
   enabled: true
   save_keypoints: true
 
+encoding:
+  enabled: false
+  input:
+    feature_dir: outputs/features
+  codebook:
+    enabled: false
+    output_dir: outputs/indices/codebooks
+    trainer: minibatch_kmeans
+    n_clusters: 256
+    max_descriptors: 50000
+    batch_size: 1024
+    random_state: 42
+
 output:
   feature_dir: outputs/features
   index_dir: outputs/indices

--- a/docs/ai/feedback/stage4/feedback_stage4-1.md
+++ b/docs/ai/feedback/stage4/feedback_stage4-1.md
@@ -1,14 +1,71 @@
-1. Added the minimal encoding foundation for Issue 4-1: a new encoding package with a validated file-reader path and a unified encoding-input path for both saved feature artifacts and in-memory `LocalFeatureResult`. The implementation is in [src/encoding/types.py](d:/MyProject/Content-Based-Image-Retrieval-System/src/encoding/types.py), [src/encoding/io.py](d:/MyProject/Content-Based-Image-Retrieval-System/src/encoding/io.py), and [src/encoding/__init__.py](d:/MyProject/Content-Based-Image-Retrieval-System/src/encoding/__init__.py). It does not change the existing extractor, `LocalFeatureResult`, or `.npz` save contract.
+# Issue 4.1 Feedback
 
-2. Files created / modified:
-   Created [src/encoding/__init__.py](d:/MyProject/Content-Based-Image-Retrieval-System/src/encoding/__init__.py), [src/encoding/types.py](d:/MyProject/Content-Based-Image-Retrieval-System/src/encoding/types.py), [src/encoding/io.py](d:/MyProject/Content-Based-Image-Retrieval-System/src/encoding/io.py), and [tests/test_encoding_io.py](d:/MyProject/Content-Based-Image-Retrieval-System/tests/test_encoding_io.py). No existing pipeline files were modified.
+## Changed
 
-3. Assumptions made:
-   Empty descriptor inputs are valid and normalize to a method-aware empty `EncodingInput`, so empty SIFT becomes shape `(0, 128)` / dtype `float32` and empty ORB becomes `(0, 32)` / `uint8`, even when the saved `.npz` metadata is empty.
-   When descriptors are present, descriptor row count must match `num_keypoints`, which matches the current extractor/save behavior.
+- `src/encoding/types.py` now defines the minimal encoding-stage data containers: `FeatureFileRecord` and `EncodingInput`.
+- `src/encoding/io.py` now implements validated feature artifact loading from `.npz` and unified encoding-input construction from both disk and in-memory local features.
+- `src/encoding/__init__.py` now exports the encoding-stage public interface.
+- `tests/test_encoding_io.py` now provides focused verification for valid SIFT inputs, valid ORB inputs, empty-descriptor inputs, in-memory conversion, and invalid metadata detection.
 
-4. Acceptance criteria coverage:
-   `FeatureFileRecord` and `EncodingInput` are implemented; `load_feature_npz(...)` reads with `allow_pickle=False`, checks required keys, validates method, `descriptors_present`, descriptor dtype/shape, and rejects inconsistent metadata. `build_encoding_input_from_feature_record(...)` and `build_encoding_input_from_local_feature(...)` both produce the same stable encoding-facing structure. Empty descriptors are handled explicitly instead of failing implicitly. Verification was added in [tests/test_encoding_io.py](d:/MyProject/Content-Based-Image-Retrieval-System/tests/test_encoding_io.py) and passes with `python -m unittest discover -s tests -p "test_encoding_io.py" -v`. I also verified the loader against one real existing saved SIFT artifact in `outputs/features/`.
+## Encoding Contract
 
-5. Leave for Issue 4-2:
-   Codebook training, descriptor sampling, BoW encoding, any histogram/output artifact format, and any pipeline/config wiring that actually runs encoding. I also left `docs/design/encoding_contract.md` out to keep this issue minimal.
+The new encoding layer now supports two input paths without changing the upstream local feature contract:
+
+- saved feature files under `outputs/features/*.npz`
+- in-memory `LocalFeatureResult`
+
+The implementation keeps the encoding interface method-aware:
+
+- `SIFT` descriptors must be `float32` with dimension `128`
+- `ORB` descriptors must be `uint8` with dimension `32`
+
+Empty descriptor cases are handled explicitly instead of failing implicitly.
+When the input is truly empty, the loader/builder returns a valid empty encoding state rather than crashing.
+
+## Validation Behavior
+
+The `.npz` loader now uses `allow_pickle=False` and validates:
+
+- required keys
+- method
+- `descriptors_present`
+- `descriptor_shape`
+- `descriptor_dtype`
+- compatibility between metadata and the actual descriptor array
+
+If metadata and descriptor content disagree, the implementation raises a clear `ValueError` instead of silently correcting the file.
+
+For normalized encoding input:
+
+- non-empty inputs keep the real descriptor array and validated metadata
+- empty inputs are normalized into a stable method-aware encoding-facing representation
+
+## Validation
+
+Commands verified:
+
+- `python -m unittest discover -s tests -p "test_encoding_io.py" -v`
+
+Observed test coverage:
+
+- valid SIFT feature `.npz` loading succeeds
+- valid ORB feature `.npz` loading succeeds
+- empty-descriptor feature `.npz` loading succeeds
+- in-memory `LocalFeatureResult` to `EncodingInput` conversion succeeds
+- invalid dtype / invalid descriptor shape metadata is rejected
+
+Real artifact compatibility check:
+
+- a real existing feature file under `outputs/features/` was loaded successfully
+- the resulting `FeatureFileRecord` and `EncodingInput` matched the saved SIFT descriptor shape and dtype
+
+## Acceptance Alignment
+
+This issue now satisfies the intended Stage 4.1 scope because:
+
+- the encoding package exists under `src/encoding/`
+- stable encoding-stage data structures are defined
+- feature files can be read safely and validated against the current `.npz` contract
+- both disk-based and in-memory local feature inputs are converted into one normalized encoding-facing structure
+- empty descriptor cases are handled explicitly
+- no codebook training, BoW encoding, TF-IDF, indexing, retrieval, or upstream pipeline redesign was added

--- a/docs/ai/feedback/stage4/feedback_stage4-2.md
+++ b/docs/ai/feedback/stage4/feedback_stage4-2.md
@@ -1,0 +1,83 @@
+# Issue 4.2 Feedback
+
+## Changed
+
+- `src/encoding/sampling.py` now implements bounded descriptor sampling from saved feature artifacts and groups samples by method.
+- `src/encoding/codebook.py` now implements method-specific codebook training, codebook artifact saving, and codebook artifact loading.
+- `src/encoding/__init__.py` now exports the new sampling and codebook interfaces.
+- `scripts/train_codebook.py` now provides a standalone offline entry point for reusable codebook training.
+- `configs/base.yaml` now includes the minimal `encoding` / `codebook` config section needed for offline training.
+- `tests/test_codebook.py` now verifies sampling behavior, method separation, codebook training, artifact save/load, and invalid dimension rejection.
+- `requirements.txt` now declares `scikit-learn` for the codebook trainer dependency.
+
+## Sampling Design
+
+The sampling stage now reads existing `outputs/features/*.npz` artifacts through the Issue 4.1 interfaces instead of introducing a parallel loader.
+
+Key behavior:
+
+- feature files are iterated in a stable order
+- each file is validated through `load_feature_npz(...)`
+- descriptors are normalized through `build_encoding_input_from_feature_record(...)`
+- empty descriptor records are skipped safely
+- descriptors are never mixed across methods
+- bounded reservoir-style sampling prevents unbounded descriptor concatenation
+
+The sampling result keeps method-aware metadata together with the sampled descriptor matrix so the next stage can train codebooks without re-reading raw feature artifacts.
+
+## Codebook Artifact
+
+The codebook stage now trains one reusable artifact per method.
+
+Current artifact format:
+
+- compressed `.npz`
+- saved under `outputs/indices/codebooks/`
+- filename format: `codebook_<method>_k<n_clusters>_<trainer>.npz`
+
+Stored fields:
+
+- `method`
+- `trainer`
+- `n_clusters`
+- `descriptor_dim`
+- `descriptor_dtype`
+- `training_descriptor_count`
+- `random_state`
+- `batch_size`
+- `cluster_centers`
+
+Validation ensures the saved metadata matches the trained cluster center matrix before the artifact is written or accepted on load.
+
+## Validation
+
+Commands verified:
+
+- `python -m unittest discover -s tests -p "test_*.py" -v`
+- `python scripts/train_codebook.py --config outputs/logs/test_train_codebook.yaml`
+
+Observed coverage:
+
+- empty descriptor records are skipped safely during sampling
+- SIFT and ORB descriptors are grouped separately
+- small synthetic SIFT-like descriptors can train a codebook
+- small synthetic ORB-like descriptors can train a codebook
+- a saved codebook artifact can be loaded back with matching metadata
+- invalid descriptor dimensionality is rejected with a clear error
+
+Observed script behavior:
+
+- the standalone script reads the configured feature directory
+- trains a method-specific codebook from saved feature artifacts
+- saves a reusable `.npz` codebook artifact under the configured output directory
+
+## Acceptance Alignment
+
+This issue now satisfies the intended Stage 4.2 scope because:
+
+- descriptor collection and capped sampling are implemented
+- empty descriptor feature records are skipped explicitly
+- codebook training is method-specific and config-driven
+- reusable codebook artifacts are saved with explicit metadata
+- a standalone offline training script exists
+- no BoW encoding, TF-IDF, indexing, retrieval, or `run_pipeline.py` integration was added

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 PyYAML>=6.0,<7.0
 opencv-python>=4.8,<5.0
 gradio>=5.0,<6.0
+scikit-learn>=1.4,<2.0

--- a/scripts/train_codebook.py
+++ b/scripts/train_codebook.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Any
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from src.encoding import sample_descriptors_by_method, save_codebook_artifact, train_codebook
+from src.utils import get_default_config_path, load_config
+
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Train method-specific codebooks from saved feature artifacts.")
+    parser.add_argument(
+        "--config",
+        default=get_default_config_path(),
+        help="Path to the runtime config file. Defaults to configs/base.yaml.",
+    )
+    parser.add_argument(
+        "--method",
+        action="append",
+        help="Optional method filter. Can be provided multiple times, e.g. --method sift --method orb.",
+    )
+    return parser.parse_args()
+
+
+
+def load_runtime_config(config_path: str) -> tuple[dict[str, Any], Path]:
+    resolved_path = Path(config_path).expanduser()
+    if not resolved_path.is_absolute():
+        resolved_path = (PROJECT_ROOT / resolved_path).resolve()
+    else:
+        resolved_path = resolved_path.resolve()
+
+    config = load_config(str(resolved_path))
+    return config, resolved_path
+
+
+
+def run_codebook_training(config: dict[str, Any], methods: list[str] | None = None) -> list[Path]:
+    encoding_config = _get_mapping(config, "encoding")
+    input_config = _get_nested_mapping(encoding_config, "input", "encoding.input")
+    codebook_config = _get_nested_mapping(encoding_config, "codebook", "encoding.codebook")
+    output_config = _get_mapping(config, "output")
+
+    if not bool(codebook_config.get("enabled", False)):
+        raise ValueError("Config field 'encoding.codebook.enabled' must be true to train codebooks.")
+
+    feature_dir = _resolve_path(
+        input_config.get("feature_dir", output_config.get("feature_dir", "outputs/features")),
+        "encoding.input.feature_dir",
+    )
+    output_dir = _resolve_path(
+        codebook_config.get("output_dir", "outputs/indices/codebooks"),
+        "encoding.codebook.output_dir",
+    )
+    trainer = _require_non_empty_string(codebook_config.get("trainer", "minibatch_kmeans"), "encoding.codebook.trainer")
+    n_clusters = _require_positive_int(codebook_config.get("n_clusters", 256), "encoding.codebook.n_clusters")
+    max_descriptors = _require_positive_int(
+        codebook_config.get("max_descriptors", 50000),
+        "encoding.codebook.max_descriptors",
+    )
+    batch_size = _require_positive_int(codebook_config.get("batch_size", 1024), "encoding.codebook.batch_size")
+    random_state = _optional_int(codebook_config.get("random_state", 42), "encoding.codebook.random_state")
+
+    descriptor_samples = sample_descriptors_by_method(
+        feature_dir=feature_dir,
+        max_descriptors=max_descriptors,
+        random_state=random_state,
+        methods=methods,
+    )
+    if not descriptor_samples:
+        raise ValueError(f"No descriptor samples were collected from {feature_dir}.")
+
+    saved_paths: list[Path] = []
+    for method, sample in descriptor_samples.items():
+        if sample.feature_file_count == 0:
+            raise ValueError(f"No feature files found for requested method {method} under {feature_dir}.")
+        if sample.descriptors is None or sample.sampled_descriptor_count == 0:
+            raise ValueError(
+                f"No non-empty descriptors available for method {method}. "
+                f"Checked {sample.feature_file_count} feature files and skipped {sample.empty_record_count} empty records."
+            )
+
+        codebook = train_codebook(
+            sample.descriptors,
+            method=method,
+            trainer=trainer,
+            n_clusters=n_clusters,
+            batch_size=batch_size,
+            random_state=random_state,
+        )
+        save_path = save_codebook_artifact(codebook, output_dir)
+        saved_paths.append(save_path)
+
+        print(
+            f"Method={method} files={sample.feature_file_count} empty={sample.empty_record_count} "
+            f"seen={sample.total_descriptor_count} sampled={sample.sampled_descriptor_count} "
+            f"clusters={codebook.n_clusters} saved={save_path}"
+        )
+
+    return saved_paths
+
+
+
+def _get_mapping(config: dict[str, Any], key: str) -> dict[str, Any]:
+    value = config.get(key)
+    if value is None:
+        return {}
+    if not isinstance(value, dict):
+        raise ValueError(f"Config section '{key}' must be a mapping.")
+    return value
+
+
+
+def _get_nested_mapping(parent: dict[str, Any], key: str, field_name: str) -> dict[str, Any]:
+    value = parent.get(key)
+    if value is None:
+        return {}
+    if not isinstance(value, dict):
+        raise ValueError(f"Config section '{field_name}' must be a mapping.")
+    return value
+
+
+
+def _resolve_path(value: Any, field_name: str) -> Path:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"Config field '{field_name}' must be a non-empty path string.")
+
+    path = Path(value).expanduser()
+    if not path.is_absolute():
+        path = (PROJECT_ROOT / path).resolve()
+    else:
+        path = path.resolve()
+    return path
+
+
+
+def _require_non_empty_string(value: Any, field_name: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"Config field '{field_name}' must be a non-empty string.")
+    return value.strip()
+
+
+
+def _require_positive_int(value: Any, field_name: str) -> int:
+    if isinstance(value, bool):
+        raise ValueError(f"Config field '{field_name}' must be a positive integer.")
+
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"Config field '{field_name}' must be a positive integer.") from exc
+
+    if parsed <= 0:
+        raise ValueError(f"Config field '{field_name}' must be greater than zero, got {parsed}.")
+    return parsed
+
+
+
+def _optional_int(value: Any, field_name: str) -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        raise ValueError(f"Config field '{field_name}' must be an integer or null.")
+
+    try:
+        return int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"Config field '{field_name}' must be an integer or null.") from exc
+
+
+
+def main() -> int:
+    args = parse_args()
+
+    try:
+        config, config_path = load_runtime_config(args.config)
+        print(f"Loaded config from {config_path}")
+        saved_paths = run_codebook_training(config, methods=args.method)
+        print(f"Codebook training completed. Saved {len(saved_paths)} artifact(s).")
+        return 0
+    except (FileNotFoundError, NotADirectoryError, ValueError, OSError, ImportError, RuntimeError, TypeError) as exc:
+        print(f"Codebook training failed: {exc}")
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/encoding/__init__.py
+++ b/src/encoding/__init__.py
@@ -1,14 +1,23 @@
+from .codebook import CodebookArtifact, load_codebook_artifact, save_codebook_artifact, train_codebook
 from .io import (
     build_encoding_input_from_feature_record,
     build_encoding_input_from_local_feature,
     load_feature_npz,
 )
+from .sampling import DescriptorSample, iter_feature_paths, sample_descriptors_by_method
 from .types import EncodingInput, FeatureFileRecord
 
 __all__ = [
+    "CodebookArtifact",
+    "DescriptorSample",
     "EncodingInput",
     "FeatureFileRecord",
     "build_encoding_input_from_feature_record",
     "build_encoding_input_from_local_feature",
+    "iter_feature_paths",
+    "load_codebook_artifact",
     "load_feature_npz",
+    "sample_descriptors_by_method",
+    "save_codebook_artifact",
+    "train_codebook",
 ]

--- a/src/encoding/codebook.py
+++ b/src/encoding/codebook.py
@@ -1,0 +1,305 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+from numpy.lib.npyio import NpzFile
+from sklearn.cluster import KMeans, MiniBatchKMeans
+
+from .io import _METHOD_SPECS, _normalize_method
+
+
+_SUPPORTED_TRAINERS = ("minibatch_kmeans", "kmeans")
+_REQUIRED_CODEBOOK_KEYS = (
+    "method",
+    "trainer",
+    "n_clusters",
+    "descriptor_dim",
+    "descriptor_dtype",
+    "training_descriptor_count",
+    "random_state",
+    "batch_size",
+    "cluster_centers",
+)
+
+
+@dataclass(slots=True)
+class CodebookArtifact:
+    """Reusable method-specific codebook artifact."""
+
+    method: str
+    trainer: str
+    n_clusters: int
+    descriptor_dim: int
+    descriptor_dtype: str
+    training_descriptor_count: int
+    random_state: int | None
+    batch_size: int | None
+    cluster_centers: np.ndarray
+
+
+
+def train_codebook(
+    descriptors: np.ndarray,
+    method: str,
+    *,
+    trainer: str = "minibatch_kmeans",
+    n_clusters: int = 256,
+    batch_size: int = 1024,
+    random_state: int | None = 42,
+) -> CodebookArtifact:
+    """Train one method-specific codebook from a validated descriptor matrix."""
+    normalized_method = _normalize_method(method)
+    normalized_trainer = _normalize_trainer(trainer)
+    validated_descriptors = _validate_training_descriptors(descriptors, normalized_method, "train_codebook")
+    resolved_clusters = _require_positive_int(n_clusters, "n_clusters")
+    resolved_random_state = _normalize_optional_int(random_state, "random_state")
+
+    if validated_descriptors.shape[0] < resolved_clusters:
+        raise ValueError(
+            f"train_codebook: n_clusters={resolved_clusters} exceeds descriptor rows={validated_descriptors.shape[0]}."
+        )
+
+    training_data = validated_descriptors.astype(np.float32, copy=False)
+    resolved_batch_size: int | None = None
+    if normalized_trainer == "minibatch_kmeans":
+        resolved_batch_size = _require_positive_int(batch_size, "batch_size")
+        estimator = MiniBatchKMeans(
+            n_clusters=resolved_clusters,
+            batch_size=resolved_batch_size,
+            random_state=resolved_random_state,
+            n_init=3,
+        )
+    else:
+        estimator = KMeans(
+            n_clusters=resolved_clusters,
+            random_state=resolved_random_state,
+            n_init=3,
+        )
+
+    estimator.fit(training_data)
+    artifact = CodebookArtifact(
+        method=normalized_method,
+        trainer=normalized_trainer,
+        n_clusters=resolved_clusters,
+        descriptor_dim=int(validated_descriptors.shape[1]),
+        descriptor_dtype=str(validated_descriptors.dtype),
+        training_descriptor_count=int(validated_descriptors.shape[0]),
+        random_state=resolved_random_state,
+        batch_size=resolved_batch_size,
+        cluster_centers=np.asarray(estimator.cluster_centers_, dtype=np.float32),
+    )
+    _validate_codebook_artifact(artifact, "trained codebook")
+    return artifact
+
+
+
+def save_codebook_artifact(codebook: CodebookArtifact, output_dir: str | Path) -> Path:
+    """Save a codebook artifact as a compressed `.npz` file."""
+    _validate_codebook_artifact(codebook, "save_codebook_artifact")
+
+    target_dir = Path(output_dir).expanduser().resolve()
+    target_dir.mkdir(parents=True, exist_ok=True)
+    save_path = target_dir / _make_codebook_name(codebook)
+
+    np.savez_compressed(
+        save_path,
+        method=np.array(codebook.method),
+        trainer=np.array(codebook.trainer),
+        n_clusters=np.array(codebook.n_clusters, dtype=np.int32),
+        descriptor_dim=np.array(codebook.descriptor_dim, dtype=np.int32),
+        descriptor_dtype=np.array(codebook.descriptor_dtype),
+        training_descriptor_count=np.array(codebook.training_descriptor_count, dtype=np.int32),
+        random_state=np.array(-1 if codebook.random_state is None else codebook.random_state, dtype=np.int32),
+        batch_size=np.array(-1 if codebook.batch_size is None else codebook.batch_size, dtype=np.int32),
+        cluster_centers=np.asarray(codebook.cluster_centers, dtype=np.float32),
+    )
+    return save_path
+
+
+
+def load_codebook_artifact(codebook_path: str | Path) -> CodebookArtifact:
+    """Load and validate a saved codebook artifact."""
+    resolved_path = Path(codebook_path).expanduser()
+    if not resolved_path.exists():
+        raise FileNotFoundError(f"Codebook artifact not found: {resolved_path}")
+    if not resolved_path.is_file():
+        raise FileNotFoundError(f"Codebook path is not a file: {resolved_path}")
+
+    with np.load(resolved_path, allow_pickle=False) as data:
+        _validate_required_keys(data, resolved_path)
+
+        artifact = CodebookArtifact(
+            method=_normalize_method(_read_required_string(data, "method", resolved_path)),
+            trainer=_normalize_trainer(_read_required_string(data, "trainer", resolved_path)),
+            n_clusters=_read_required_int(data, "n_clusters", resolved_path),
+            descriptor_dim=_read_required_int(data, "descriptor_dim", resolved_path),
+            descriptor_dtype=_read_required_string(data, "descriptor_dtype", resolved_path),
+            training_descriptor_count=_read_required_int(data, "training_descriptor_count", resolved_path),
+            random_state=_read_optional_int(data, "random_state", resolved_path),
+            batch_size=_read_optional_int(data, "batch_size", resolved_path),
+            cluster_centers=np.array(data["cluster_centers"], copy=True),
+        )
+
+    _validate_codebook_artifact(artifact, resolved_path)
+    return artifact
+
+
+
+def _validate_training_descriptors(descriptors: Any, method: str, source: str) -> np.ndarray:
+    if not isinstance(descriptors, np.ndarray):
+        raise TypeError(f"{source}: descriptors must be a numpy.ndarray, got {type(descriptors).__name__}.")
+    if descriptors.ndim != 2:
+        raise ValueError(f"{source}: descriptors must be a 2D array, got shape={descriptors.shape}.")
+    if descriptors.shape[0] <= 0:
+        raise ValueError(f"{source}: descriptors must contain at least one row.")
+
+    spec = _METHOD_SPECS[method]
+    actual_dtype = str(descriptors.dtype)
+    actual_dim = int(descriptors.shape[1])
+    if actual_dtype != spec.dtype:
+        raise ValueError(f"{source}: {method} descriptors must have dtype {spec.dtype}, got {actual_dtype}.")
+    if actual_dim != spec.dim:
+        raise ValueError(f"{source}: {method} descriptors must have dimension {spec.dim}, got {actual_dim}.")
+    return descriptors
+
+
+
+def _validate_codebook_artifact(codebook: CodebookArtifact, source: Any) -> None:
+    if not isinstance(codebook, CodebookArtifact):
+        raise TypeError(f"{source}: codebook must be a CodebookArtifact, got {type(codebook).__name__}.")
+
+    method = _normalize_method(codebook.method)
+    trainer = _normalize_trainer(codebook.trainer)
+    n_clusters = _require_positive_int(codebook.n_clusters, "n_clusters")
+    descriptor_dim = _require_positive_int(codebook.descriptor_dim, "descriptor_dim")
+    training_descriptor_count = _require_positive_int(codebook.training_descriptor_count, "training_descriptor_count")
+    random_state = _normalize_optional_int(codebook.random_state, "random_state")
+    batch_size = None if codebook.batch_size is None else _require_positive_int(codebook.batch_size, "batch_size")
+
+    spec = _METHOD_SPECS[method]
+    if descriptor_dim != spec.dim:
+        raise ValueError(f"{source}: {method} codebook descriptor_dim must be {spec.dim}, got {descriptor_dim}.")
+    if codebook.descriptor_dtype != spec.dtype:
+        raise ValueError(
+            f"{source}: {method} codebook descriptor_dtype must be {spec.dtype}, got {codebook.descriptor_dtype!r}."
+        )
+    if training_descriptor_count < n_clusters:
+        raise ValueError(
+            f"{source}: training_descriptor_count={training_descriptor_count} must be >= n_clusters={n_clusters}."
+        )
+    if trainer == "minibatch_kmeans" and batch_size is None:
+        raise ValueError(f"{source}: batch_size is required for trainer 'minibatch_kmeans'.")
+
+    centers = codebook.cluster_centers
+    if not isinstance(centers, np.ndarray):
+        raise TypeError(f"{source}: cluster_centers must be a numpy.ndarray, got {type(centers).__name__}.")
+    if centers.ndim != 2:
+        raise ValueError(f"{source}: cluster_centers must be a 2D array, got shape={centers.shape}.")
+    if centers.shape != (n_clusters, descriptor_dim):
+        raise ValueError(
+            f"{source}: cluster_centers shape {centers.shape} does not match "
+            f"(n_clusters={n_clusters}, descriptor_dim={descriptor_dim})."
+        )
+    if not np.issubdtype(centers.dtype, np.floating):
+        raise ValueError(f"{source}: cluster_centers must use a floating dtype, got {centers.dtype}.")
+
+    codebook.method = method
+    codebook.trainer = trainer
+    codebook.n_clusters = n_clusters
+    codebook.descriptor_dim = descriptor_dim
+    codebook.training_descriptor_count = training_descriptor_count
+    codebook.random_state = random_state
+    codebook.batch_size = batch_size
+    codebook.cluster_centers = np.asarray(centers, dtype=np.float32)
+
+
+
+def _make_codebook_name(codebook: CodebookArtifact) -> str:
+    return f"codebook_{codebook.method.lower()}_k{codebook.n_clusters}_{codebook.trainer}.npz"
+
+
+
+def _validate_required_keys(data: NpzFile, source: Path) -> None:
+    missing_keys = [key for key in _REQUIRED_CODEBOOK_KEYS if key not in data.files]
+    if missing_keys:
+        raise ValueError(f"{source}: missing required codebook keys: {', '.join(missing_keys)}.")
+
+
+
+def _normalize_trainer(trainer: str) -> str:
+    if not isinstance(trainer, str) or not trainer.strip():
+        raise ValueError("Codebook trainer must be a non-empty string.")
+
+    normalized = trainer.strip().lower()
+    if normalized not in _SUPPORTED_TRAINERS:
+        raise ValueError(
+            f"Unsupported codebook trainer: {trainer!r}. Supported trainers: {', '.join(_SUPPORTED_TRAINERS)}."
+        )
+    return normalized
+
+
+
+def _read_required_string(data: NpzFile, key: str, source: Any) -> str:
+    value = data[key]
+    if value.ndim != 0:
+        raise ValueError(f"{source}: key '{key}' must be a scalar string value.")
+
+    scalar = value.item()
+    if not isinstance(scalar, str) or not scalar.strip():
+        raise ValueError(f"{source}: key '{key}' must be a non-empty string.")
+    return scalar.strip()
+
+
+
+def _read_required_int(data: NpzFile, key: str, source: Any) -> int:
+    value = data[key]
+    if value.ndim != 0:
+        raise ValueError(f"{source}: key '{key}' must be a scalar integer value.")
+
+    return _require_positive_int(value.item(), f"{source}: key '{key}'")
+
+
+
+def _read_optional_int(data: NpzFile, key: str, source: Any) -> int | None:
+    value = data[key]
+    if value.ndim != 0:
+        raise ValueError(f"{source}: key '{key}' must be a scalar integer value.")
+
+    parsed = int(value.item())
+    if parsed == -1:
+        return None
+    if parsed < 0:
+        raise ValueError(f"{source}: key '{key}' must be >= 0 or -1 for None, got {parsed}.")
+    return parsed
+
+
+
+def _normalize_optional_int(value: Any, field_name: str) -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        raise ValueError(f"{field_name} must be an integer or None.")
+
+    try:
+        return int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{field_name} must be an integer or None.") from exc
+
+
+
+def _require_positive_int(value: Any, field_name: str) -> int:
+    if isinstance(value, bool):
+        raise ValueError(f"{field_name} must be a positive integer.")
+
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{field_name} must be a positive integer.") from exc
+
+    if parsed <= 0:
+        raise ValueError(f"{field_name} must be greater than zero, got {parsed}.")
+    return parsed
+

--- a/src/encoding/sampling.py
+++ b/src/encoding/sampling.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable, Iterator
+
+import numpy as np
+
+from .io import _METHOD_SPECS, _normalize_method, build_encoding_input_from_feature_record, load_feature_npz
+
+
+@dataclass(slots=True)
+class DescriptorSample:
+    """Bounded method-specific descriptor sample collected from saved feature files."""
+
+    method: str
+    descriptors: np.ndarray | None
+    descriptor_dim: int
+    descriptor_dtype: str
+    total_descriptor_count: int
+    sampled_descriptor_count: int
+    feature_file_count: int
+    empty_record_count: int
+
+
+@dataclass(slots=True)
+class _SamplingState:
+    method: str
+    descriptor_dim: int
+    descriptor_dtype: str
+    capacity: int
+    reservoir: np.ndarray | None = None
+    total_descriptor_count: int = 0
+    sampled_descriptor_count: int = 0
+    feature_file_count: int = 0
+    empty_record_count: int = 0
+
+
+
+def iter_feature_paths(feature_dir: str | Path) -> Iterator[Path]:
+    """Yield saved feature artifact paths in a stable sorted order."""
+    resolved_dir = Path(feature_dir).expanduser()
+    if not resolved_dir.exists():
+        raise FileNotFoundError(f"Feature directory not found: {resolved_dir}")
+    if not resolved_dir.is_dir():
+        raise NotADirectoryError(f"Feature path is not a directory: {resolved_dir}")
+
+    yield from sorted(path for path in resolved_dir.glob("*.npz") if path.is_file())
+
+
+
+def sample_descriptors_by_method(
+    feature_dir: str | Path,
+    max_descriptors: int,
+    random_state: int | None = 42,
+    methods: Iterable[str] | None = None,
+) -> dict[str, DescriptorSample]:
+    """Collect a bounded descriptor sample per method from saved feature artifacts."""
+    capacity = _require_positive_int(max_descriptors, "max_descriptors")
+    rng = np.random.default_rng(random_state)
+    feature_paths = list(iter_feature_paths(feature_dir))
+    if not feature_paths:
+        raise FileNotFoundError(f"No feature files found under: {Path(feature_dir).expanduser()}")
+
+    allowed_methods = _normalize_method_filter(methods)
+    states: dict[str, _SamplingState] = {}
+    if allowed_methods is not None:
+        for method in allowed_methods:
+            states[method] = _make_sampling_state(method, capacity)
+
+    for feature_path in feature_paths:
+        record = load_feature_npz(feature_path)
+        encoding_input = build_encoding_input_from_feature_record(record)
+        method = encoding_input.method
+
+        if allowed_methods is not None and method not in allowed_methods:
+            continue
+
+        state = states.get(method)
+        if state is None:
+            state = _make_sampling_state(method, capacity)
+            states[method] = state
+
+        state.feature_file_count += 1
+        if not encoding_input.descriptors_present or encoding_input.descriptors is None:
+            state.empty_record_count += 1
+            continue
+
+        _validate_sampling_input(state, encoding_input, feature_path)
+        _update_reservoir(state, encoding_input.descriptors, rng)
+
+    return {method: _finalize_sampling_state(state) for method, state in sorted(states.items())}
+
+
+
+def _normalize_method_filter(methods: Iterable[str] | None) -> tuple[str, ...] | None:
+    if methods is None:
+        return None
+
+    normalized = []
+    for method in methods:
+        normalized.append(_normalize_method(method))
+    return tuple(sorted(set(normalized)))
+
+
+
+def _make_sampling_state(method: str, capacity: int) -> _SamplingState:
+    spec = _METHOD_SPECS[method]
+    return _SamplingState(
+        method=method,
+        descriptor_dim=spec.dim,
+        descriptor_dtype=spec.dtype,
+        capacity=capacity,
+    )
+
+
+
+def _validate_sampling_input(state: _SamplingState, encoding_input: Any, source: Path) -> None:
+    if encoding_input.descriptor_dim != state.descriptor_dim:
+        raise ValueError(
+            f"{source}: descriptor_dim {encoding_input.descriptor_dim} does not match "
+            f"existing {state.method} sampling dim {state.descriptor_dim}."
+        )
+    if encoding_input.descriptor_dtype != state.descriptor_dtype:
+        raise ValueError(
+            f"{source}: descriptor_dtype {encoding_input.descriptor_dtype!r} does not match "
+            f"existing {state.method} sampling dtype {state.descriptor_dtype!r}."
+        )
+
+
+
+def _update_reservoir(state: _SamplingState, descriptors: np.ndarray, rng: np.random.Generator) -> None:
+    if state.reservoir is None:
+        state.reservoir = np.empty((state.capacity, state.descriptor_dim), dtype=descriptors.dtype)
+
+    for row in descriptors:
+        state.total_descriptor_count += 1
+        if state.sampled_descriptor_count < state.capacity:
+            state.reservoir[state.sampled_descriptor_count] = row
+            state.sampled_descriptor_count += 1
+            continue
+
+        replace_index = int(rng.integers(0, state.total_descriptor_count))
+        if replace_index < state.capacity:
+            state.reservoir[replace_index] = row
+
+
+
+def _finalize_sampling_state(state: _SamplingState) -> DescriptorSample:
+    descriptors: np.ndarray | None = None
+    if state.reservoir is not None and state.sampled_descriptor_count > 0:
+        descriptors = state.reservoir[: state.sampled_descriptor_count].copy()
+
+    return DescriptorSample(
+        method=state.method,
+        descriptors=descriptors,
+        descriptor_dim=state.descriptor_dim,
+        descriptor_dtype=state.descriptor_dtype,
+        total_descriptor_count=state.total_descriptor_count,
+        sampled_descriptor_count=state.sampled_descriptor_count,
+        feature_file_count=state.feature_file_count,
+        empty_record_count=state.empty_record_count,
+    )
+
+
+
+def _require_positive_int(value: int, field_name: str) -> int:
+    if isinstance(value, bool):
+        raise ValueError(f"{field_name} must be a positive integer.")
+
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{field_name} must be a positive integer.") from exc
+
+    if parsed <= 0:
+        raise ValueError(f"{field_name} must be greater than zero, got {parsed}.")
+    return parsed
+

--- a/tests/test_codebook.py
+++ b/tests/test_codebook.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+import shutil
+import unittest
+import uuid
+from pathlib import Path
+
+import numpy as np
+
+from src.encoding import (
+    load_codebook_artifact,
+    sample_descriptors_by_method,
+    save_codebook_artifact,
+    train_codebook,
+)
+
+
+class CodebookTests(unittest.TestCase):
+    def test_sampling_skips_empty_records_and_applies_cap(self) -> None:
+        feature_dir = self._make_temp_dir("features")
+        self._write_feature_npz(feature_dir / "empty_sift.npz", method="SIFT", descriptors=None)
+        self._write_feature_npz(
+            feature_dir / "non_empty_sift.npz",
+            method="SIFT",
+            descriptors=np.arange(3 * 128, dtype=np.float32).reshape(3, 128),
+        )
+
+        samples = sample_descriptors_by_method(feature_dir, max_descriptors=2, random_state=0)
+
+        self.assertEqual(set(samples), {"SIFT"})
+        sift_sample = samples["SIFT"]
+        self.assertEqual(sift_sample.feature_file_count, 2)
+        self.assertEqual(sift_sample.empty_record_count, 1)
+        self.assertEqual(sift_sample.total_descriptor_count, 3)
+        self.assertEqual(sift_sample.sampled_descriptor_count, 2)
+        self.assertEqual(sift_sample.descriptors.shape, (2, 128))
+        self.assertEqual(str(sift_sample.descriptors.dtype), "float32")
+
+    def test_sampling_groups_methods_separately(self) -> None:
+        feature_dir = self._make_temp_dir("features")
+        self._write_feature_npz(
+            feature_dir / "sample_sift.npz",
+            method="SIFT",
+            descriptors=np.ones((2, 128), dtype=np.float32),
+        )
+        self._write_feature_npz(
+            feature_dir / "sample_orb.npz",
+            method="ORB",
+            descriptors=np.full((4, 32), 9, dtype=np.uint8),
+        )
+
+        samples = sample_descriptors_by_method(feature_dir, max_descriptors=10, random_state=0)
+
+        self.assertEqual(set(samples), {"ORB", "SIFT"})
+        self.assertEqual(samples["SIFT"].descriptors.shape, (2, 128))
+        self.assertEqual(str(samples["SIFT"].descriptors.dtype), "float32")
+        self.assertEqual(samples["ORB"].descriptors.shape, (4, 32))
+        self.assertEqual(str(samples["ORB"].descriptors.dtype), "uint8")
+
+    def test_train_codebook_on_sift_descriptors(self) -> None:
+        descriptors = self._make_sift_descriptors()
+
+        codebook = train_codebook(
+            descriptors,
+            method="SIFT",
+            trainer="minibatch_kmeans",
+            n_clusters=2,
+            batch_size=2,
+            random_state=0,
+        )
+
+        self.assertEqual(codebook.method, "SIFT")
+        self.assertEqual(codebook.n_clusters, 2)
+        self.assertEqual(codebook.descriptor_dim, 128)
+        self.assertEqual(codebook.descriptor_dtype, "float32")
+        self.assertEqual(codebook.cluster_centers.shape, (2, 128))
+        self.assertEqual(str(codebook.cluster_centers.dtype), "float32")
+
+    def test_train_codebook_on_orb_descriptors(self) -> None:
+        descriptors = self._make_orb_descriptors()
+
+        codebook = train_codebook(
+            descriptors,
+            method="ORB",
+            trainer="minibatch_kmeans",
+            n_clusters=2,
+            batch_size=2,
+            random_state=0,
+        )
+
+        self.assertEqual(codebook.method, "ORB")
+        self.assertEqual(codebook.n_clusters, 2)
+        self.assertEqual(codebook.descriptor_dim, 32)
+        self.assertEqual(codebook.descriptor_dtype, "uint8")
+        self.assertEqual(codebook.cluster_centers.shape, (2, 32))
+
+    def test_saved_codebook_can_be_loaded(self) -> None:
+        output_dir = self._make_temp_dir("indices")
+        codebook = train_codebook(
+            self._make_sift_descriptors(),
+            method="SIFT",
+            trainer="minibatch_kmeans",
+            n_clusters=2,
+            batch_size=2,
+            random_state=0,
+        )
+
+        save_path = save_codebook_artifact(codebook, output_dir)
+        loaded = load_codebook_artifact(save_path)
+
+        self.assertEqual(loaded.method, "SIFT")
+        self.assertEqual(loaded.trainer, "minibatch_kmeans")
+        self.assertEqual(loaded.n_clusters, 2)
+        self.assertEqual(loaded.descriptor_dim, 128)
+        self.assertEqual(loaded.training_descriptor_count, codebook.training_descriptor_count)
+        self.assertEqual(loaded.cluster_centers.shape, (2, 128))
+
+    def test_inconsistent_descriptor_dim_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            train_codebook(
+                np.ones((4, 64), dtype=np.float32),
+                method="SIFT",
+                trainer="minibatch_kmeans",
+                n_clusters=2,
+                batch_size=2,
+                random_state=0,
+            )
+
+    def _make_temp_dir(self, kind: str) -> Path:
+        root = Path("outputs") / kind / "test_tmp"
+        root.mkdir(parents=True, exist_ok=True)
+        temp_dir = root / uuid.uuid4().hex
+        temp_dir.mkdir(parents=True, exist_ok=True)
+        self.addCleanup(lambda: shutil.rmtree(temp_dir, ignore_errors=True))
+        return temp_dir
+
+    def _make_sift_descriptors(self) -> np.ndarray:
+        cluster_a = np.zeros((3, 128), dtype=np.float32)
+        cluster_b = np.full((3, 128), 5.0, dtype=np.float32)
+        return np.vstack([cluster_a, cluster_b])
+
+    def _make_orb_descriptors(self) -> np.ndarray:
+        cluster_a = np.zeros((3, 32), dtype=np.uint8)
+        cluster_b = np.full((3, 32), 255, dtype=np.uint8)
+        return np.vstack([cluster_a, cluster_b])
+
+    def _write_feature_npz(self, path: Path, method: str, descriptors: np.ndarray | None) -> Path:
+        num_keypoints = 0 if descriptors is None else int(descriptors.shape[0])
+        keypoints = np.zeros((num_keypoints, 7), dtype=np.float32)
+        descriptors_present = descriptors is not None
+        descriptors_to_save = descriptors if descriptors is not None else np.empty((0, 0), dtype=np.float32)
+
+        np.savez_compressed(
+            path,
+            sample_id=np.array(path.stem),
+            method=np.array(method),
+            num_keypoints=np.array(num_keypoints, dtype=np.int32),
+            keypoints=keypoints,
+            descriptors=descriptors_to_save,
+            descriptors_present=np.array(int(descriptors_present), dtype=np.uint8),
+            descriptor_shape=np.array(() if descriptors is None else descriptors.shape, dtype=np.int32),
+            descriptor_dtype=np.array("" if descriptors is None else str(descriptors.dtype)),
+            keypoint_fields=np.array(("x", "y", "size", "angle", "response", "octave", "class_id")),
+        )
+        return path
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
What:
- add bounded method-aware descriptor sampling from saved feature artifacts under `src/encoding/sampling.py`
- add method-specific codebook training, `.npz` artifact persistence, and the standalone `scripts/train_codebook.py` entry
- extend `configs/base.yaml` and add focused tests for sampling, training, and codebook reload behavior

Why:
- prepare the encoding stage with reusable method-specific codebooks without changing the existing local feature pipeline
- make offline training safe for empty descriptor cases and prevent SIFT / ORB contamination
- provide the minimal executable foundation needed for the next BoW encoding issue