### PR TITLE
feat(encoding | stage4-3): add BoW encoding and encoded feature persistence

### DIFF
--- a/configs/base.yaml
+++ b/configs/base.yaml
@@ -42,6 +42,11 @@ encoding:
     max_descriptors: 50000
     batch_size: 1024
     random_state: 42
+  bow:
+    enabled: false
+    codebook_dir: outputs/indices/codebooks
+    output_dir: outputs/encoded
+    normalize: false
 
 output:
   feature_dir: outputs/features

--- a/docs/ai/feedback/stage4/feedback_stage4-3.md
+++ b/docs/ai/feedback/stage4/feedback_stage4-3.md
@@ -1,0 +1,82 @@
+# Issue 4.3 Feedback
+
+## Changed
+
+- `src/encoding/bow.py` now implements method-aware visual word assignment, BoW histogram construction, empty-safe encoding, and minimal batch offline encoding from saved feature files.
+- `src/encoding/storage.py` now defines `EncodedFeatureResult` and the stable encoded artifact save/load helpers.
+- `src/encoding/__init__.py` now exports the BoW and encoded-storage interfaces.
+- `scripts/encode_features.py` now provides a standalone offline entry point for batch BoW encoding.
+- `configs/base.yaml` now includes the minimal `encoding.bow` config section for offline encoded-feature generation.
+- `tests/test_bow.py` now verifies BoW encoding, empty-descriptor handling, mismatch validation, and encoded artifact roundtrip behavior.
+
+## BoW Design
+
+The BoW stage now reuses the existing encoding and codebook interfaces instead of adding parallel loaders.
+
+Encoding flow:
+
+- load feature artifact through `src/encoding/io.py`
+- build `EncodingInput`
+- load the matching method-specific codebook through `src/encoding/codebook.py`
+- assign each descriptor to its nearest cluster center
+- build an image-level histogram of length `n_clusters`
+
+Key behavior:
+
+- SIFT features only pair with SIFT codebooks
+- ORB features only pair with ORB codebooks
+- empty descriptor inputs produce a valid zero histogram instead of being skipped
+- raw BoW counts remain the default representation
+- optional histogram normalization is supported but no TF-IDF fields are introduced
+
+## Encoded Artifact Contract
+
+The encoded artifact is saved as a compressed `.npz` under `outputs/encoded/`.
+
+Stored fields:
+
+- `sample_id`
+- `method`
+- `encoding_type`
+- `num_visual_words`
+- `histogram`
+- `histogram_dtype`
+- `num_descriptors`
+- `descriptors_present`
+- `codebook_path`
+- `normalized`
+
+This keeps the persisted format minimal and stable while providing the metadata needed for the next TF-IDF and indexing stages.
+
+## Validation
+
+Commands verified:
+
+- `python -m unittest discover -s tests -p "test_*.py" -v`
+- `python scripts/encode_features.py --config outputs/logs/test_encode_features.yaml`
+
+Observed coverage:
+
+- BoW encoding works for small synthetic SIFT-like descriptors
+- BoW encoding works for small synthetic ORB-like descriptors
+- empty descriptors produce zero histograms with the correct vocabulary size
+- mismatched method / codebook pairs fail clearly
+- mismatched descriptor dimensionality fails clearly
+- encoded feature artifacts save and load back with matching metadata
+
+Observed batch behavior:
+
+- the standalone script reads saved feature artifacts and method-specific codebooks from disk
+- batch encoding writes stable `.npz` encoded outputs under the configured directory
+- the batch path does not modify `run_pipeline.py`
+
+## Acceptance Alignment
+
+This issue now satisfies the intended Stage 4.3 scope because:
+
+- codebooks can be loaded and used for visual word assignment
+- image-level BoW histograms are produced from valid encoding inputs
+- empty-descriptor samples are encoded into valid zero histograms
+- encoded feature artifacts are persisted and loadable back
+- a minimal offline batch encoding path exists
+- no DF, IDF, TF-IDF, indexing, retrieval, or pipeline redesign was added

--- a/docs/ai/prompt/stage4/prompt_stage4-3.md
+++ b/docs/ai/prompt/stage4/prompt_stage4-3.md
@@ -1,0 +1,330 @@
+You are assisting an existing research-engineering repository for a Hybrid Image Retrieval System.
+
+This is NOT a fresh project.
+Do NOT redesign the system.
+You must continue from the current implemented state.
+
+==================================================
+0. BRANCH CONTEXT
+==================================================
+
+Suggested branch: feat/encoding
+
+==================================================
+1. READ FIRST
+==================================================
+
+Before making any changes, read these files first and use them as the source of truth:
+
+1. docs/ai/PROJECT_CONTEXT.md
+2. docs/design/pipeline_skeleton.md
+3. docs/design/dataset_structure.md
+4. configs/base.yaml
+5. src/encoding/types.py
+6. src/encoding/io.py
+7. src/encoding/sampling.py
+8. src/encoding/codebook.py
+9. scripts/train_codebook.py
+10. tests/test_encoding_io.py
+11. tests/test_codebook.py
+
+If any exact path differs slightly in the repository, find the closest exact file and proceed carefully.
+Do not assume missing structure without checking the repo.
+
+==================================================
+2. CURRENT SYSTEM STATE
+==================================================
+
+The implemented pipeline is currently:
+
+raw image
+→ dataset loader
+→ preprocess
+→ local feature extraction (SIFT / ORB)
+→ feature save (.npz)
+→ keypoint visualization (.png)
+
+Stage 4.1 and Stage 4.2 are assumed completed:
+
+- src/encoding/types.py and src/encoding/io.py exist
+- feature `.npz` loading and EncodingInput conversion exist
+- src/encoding/sampling.py exists
+- src/encoding/codebook.py exists
+- method-specific codebook training and save/load exist
+- scripts/train_codebook.py exists
+
+Existing contracts that MUST remain unchanged:
+- LocalFeatureResult structure
+- outputs/features/*.npz contract
+- support for BOTH SIFT and ORB
+- explicit handling of empty descriptors
+
+Upstream feature file keys include:
+- sample_id
+- method
+- num_keypoints
+- keypoints
+- descriptors
+- descriptors_present
+- descriptor_shape
+- descriptor_dtype
+- keypoint_fields
+
+Current codebook artifact is reusable and method-specific.
+Do not redesign it unless a very small compatibility-safe change is absolutely necessary.
+
+==================================================
+3. TASK
+==================================================
+
+Implement Issue 4-3:
+
+BoW Encoding and Encoded Feature Persistence
+
+Goal:
+Given a feature artifact or encoding input plus the matching method-specific codebook,
+map local descriptors to visual words and produce an image-level BoW histogram.
+Then save the encoded feature artifact in a stable format for later TF-IDF and indexing stages.
+
+This issue is ONLY about:
+- loading codebooks
+- descriptor quantization / visual word assignment
+- image-level BoW histogram construction
+- encoded feature persistence
+- minimal batch offline encoding support
+
+==================================================
+4. IN SCOPE
+==================================================
+
+You should implement:
+
+1. New modules:
+   - src/encoding/bow.py
+   - src/encoding/storage.py
+
+2. A lightweight result structure for encoded outputs, e.g.:
+   - EncodedFeatureResult
+
+3. BoW encoding logic:
+   - input: EncodingInput or feature `.npz` derived input
+   - input: matching method-specific codebook
+   - output: image-level histogram over visual words
+
+4. Explicit empty-descriptor behavior:
+   - if descriptors are absent, return a valid empty-safe BoW result
+   - histogram must still have the correct vocabulary size
+
+5. Encoded artifact persistence:
+   - save encoded outputs to outputs/encoded/*.npz
+   - add load helpers for later stages
+
+6. A minimal batch offline encoding function or script-level callable path
+   - enough to encode saved feature artifacts in batch
+   - do NOT integrate into run_pipeline.py yet
+
+7. Minimal tests or verification coverage
+
+Optional but recommended:
+- docs/design/encoded_feature_contract.md
+
+==================================================
+5. OUT OF SCOPE
+==================================================
+
+Do NOT implement any of the following in this issue:
+
+- DF statistics
+- IDF computation
+- TF-IDF vectors
+- inverted index
+- retrieval / ranking
+- reranking
+- run_pipeline.py integration
+- pipeline redesign
+- deep features / dense retrieval
+
+This issue must remain focused on BoW encoding and encoded artifact storage only.
+
+==================================================
+6. DESIGN REQUIREMENTS
+==================================================
+
+A. Reuse prior interfaces
+
+Use the existing Issue 4.1 and 4.2 interfaces:
+- feature loading through src/encoding/io.py
+- codebook loading through src/encoding/codebook.py
+
+Do not add parallel ad hoc loaders unless absolutely necessary.
+
+B. Method-aware encoding
+
+Do NOT assume a single descriptor type.
+
+Support:
+- SIFT descriptors with SIFT codebook
+- ORB descriptors with ORB codebook
+
+Never allow mismatched method/codebook pairing silently.
+Fail clearly if a SIFT feature is paired with an ORB codebook or vice versa.
+
+C. BoW output semantics
+
+This stage is still feature encoding, not TF-IDF.
+
+So the saved representation should be:
+- raw term counts
+or
+- optionally normalized histogram
+
+But it must NOT include DF / IDF weighting.
+
+Keep the design simple and explicit.
+
+D. Empty-safe behavior
+
+If descriptors_present == 0 or descriptors are empty:
+- return a valid histogram of zeros
+- preserve metadata
+- do not crash
+- do not skip the sample silently
+
+E. Stable encoded artifact format
+
+The encoded artifact must be suitable for later TF-IDF and indexing stages.
+
+At minimum persist:
+- sample_id
+- method
+- encoding_type ("bow")
+- num_visual_words
+- histogram
+- histogram_dtype
+- num_descriptors
+- descriptors_present
+- codebook_path or codebook_id
+
+You may include a few additional minimal metadata fields if they improve stability,
+but do not overdesign the format.
+
+F. Simple module boundaries
+
+Recommended responsibilities:
+
+src/encoding/bow.py
+- visual word assignment
+- histogram generation
+- empty-safe encoding
+- validation of codebook / descriptor compatibility
+
+src/encoding/storage.py
+- EncodedFeatureResult
+- save_encoded_feature(...)
+- load_encoded_feature(...)
+
+Keep boundaries obvious and minimal.
+
+==================================================
+7. IMPLEMENTATION GUIDANCE
+==================================================
+
+Use a minimal classical BoW implementation.
+
+Recommended approach:
+1. load EncodingInput
+2. load matching codebook artifact
+3. compute nearest codeword index for each descriptor
+4. build histogram of size n_clusters
+5. store result and metadata
+
+Acceptable implementation choices:
+- nearest-cluster assignment based on cluster centers
+- numpy/scikit-learn utilities if already appropriate
+
+Prefer the smallest correct solution.
+
+Do not introduce VLAD, Fisher Vector, soft assignment, or ANN search.
+
+If you support optional histogram normalization, make it config-free or very lightly parameterized,
+and keep raw count semantics clearly available.
+
+==================================================
+8. VALIDATION RULES
+==================================================
+
+Implement clear validation rules.
+
+Examples:
+
+1. Method compatibility
+- feature method must match codebook method
+- otherwise raise a clear error
+
+2. Descriptor dimensionality
+- descriptor dim must match codebook descriptor_dim
+- otherwise raise a clear error
+
+3. Empty input
+- empty descriptors must yield a zero histogram of length n_clusters
+- metadata must remain valid
+
+4. Histogram integrity
+- histogram length must equal n_clusters
+- histogram dtype must be explicit and stable
+
+5. Persistence integrity
+- a saved encoded artifact must be loadable back with matching metadata
+
+Do not silently repair corrupted data.
+
+==================================================
+9. TESTS / VERIFICATION
+==================================================
+
+Add at least minimal verification.
+
+Preferred:
+- tests/test_bow.py
+
+Cover at least:
+1. BoW encoding works for small synthetic SIFT-like descriptors with a matching codebook
+2. BoW encoding works for small synthetic ORB-like descriptors with a matching codebook
+3. empty descriptors produce a zero histogram with correct length
+4. mismatched method/codebook raises a clear error
+5. mismatched descriptor dimensionality raises a clear error
+6. encoded artifact save/load roundtrip works
+
+If repository conventions support a small helper for batch encoding verification, include it.
+Do not create a large suite. Keep it focused.
+
+==================================================
+10. OUTPUT EXPECTATION
+==================================================
+
+Deliver production-quality code with:
+- clear typing
+- concise docstrings
+- minimal but robust validation
+- stable encoded artifact format
+- no TF-IDF / indexing / retrieval logic
+- no regression to existing behavior
+
+==================================================
+11. FINAL RESPONSE FORMAT
+==================================================
+
+At the end, provide:
+
+1. A short summary of what was added
+2. The exact files created / modified
+3. The encoded artifact format you chose
+4. Any assumptions made
+5. How the implementation satisfies the acceptance criteria
+6. What is intentionally left for Issue 4-4 and later stages
+
+Do not overclaim.
+If something could not be completed, say so clearly.
+
+Please keep the encoded artifact format minimal and stable.
+Do not anticipate TF-IDF fields yet.

--- a/scripts/encode_features.py
+++ b/scripts/encode_features.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Any
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from src.encoding import encode_feature_directory
+from src.utils import get_default_config_path, load_config
+
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Encode saved feature artifacts into BoW histograms.")
+    parser.add_argument(
+        "--config",
+        default=get_default_config_path(),
+        help="Path to the runtime config file. Defaults to configs/base.yaml.",
+    )
+    parser.add_argument(
+        "--method",
+        action="append",
+        help="Optional method filter. Can be provided multiple times, e.g. --method sift --method orb.",
+    )
+    return parser.parse_args()
+
+
+
+def load_runtime_config(config_path: str) -> tuple[dict[str, Any], Path]:
+    resolved_path = Path(config_path).expanduser()
+    if not resolved_path.is_absolute():
+        resolved_path = (PROJECT_ROOT / resolved_path).resolve()
+    else:
+        resolved_path = resolved_path.resolve()
+
+    config = load_config(str(resolved_path))
+    return config, resolved_path
+
+
+
+def run_feature_encoding(config: dict[str, Any], methods: list[str] | None = None) -> list[Path]:
+    encoding_config = _get_mapping(config, "encoding")
+    input_config = _get_nested_mapping(encoding_config, "input", "encoding.input")
+    codebook_config = _get_nested_mapping(encoding_config, "codebook", "encoding.codebook")
+    bow_config = _get_nested_mapping(encoding_config, "bow", "encoding.bow")
+    output_config = _get_mapping(config, "output")
+
+    if not bool(bow_config.get("enabled", False)):
+        raise ValueError("Config field 'encoding.bow.enabled' must be true to encode features.")
+
+    feature_dir = _resolve_path(
+        input_config.get("feature_dir", output_config.get("feature_dir", "outputs/features")),
+        "encoding.input.feature_dir",
+    )
+    codebook_dir = _resolve_path(
+        bow_config.get("codebook_dir", codebook_config.get("output_dir", "outputs/indices/codebooks")),
+        "encoding.bow.codebook_dir",
+    )
+    encoded_dir = _resolve_path(
+        bow_config.get("output_dir", "outputs/encoded"),
+        "encoding.bow.output_dir",
+    )
+    normalize = _require_bool(bow_config.get("normalize", False), "encoding.bow.normalize")
+
+    saved_paths = encode_feature_directory(
+        feature_dir=feature_dir,
+        codebook_dir=codebook_dir,
+        output_dir=encoded_dir,
+        normalize=normalize,
+        methods=methods,
+    )
+    print(
+        f"Encoded {len(saved_paths)} feature artifact(s) from {feature_dir} using codebooks in {codebook_dir}."
+    )
+    return saved_paths
+
+
+
+def _get_mapping(config: dict[str, Any], key: str) -> dict[str, Any]:
+    value = config.get(key)
+    if value is None:
+        return {}
+    if not isinstance(value, dict):
+        raise ValueError(f"Config section '{key}' must be a mapping.")
+    return value
+
+
+
+def _get_nested_mapping(parent: dict[str, Any], key: str, field_name: str) -> dict[str, Any]:
+    value = parent.get(key)
+    if value is None:
+        return {}
+    if not isinstance(value, dict):
+        raise ValueError(f"Config section '{field_name}' must be a mapping.")
+    return value
+
+
+
+def _resolve_path(value: Any, field_name: str) -> Path:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"Config field '{field_name}' must be a non-empty path string.")
+
+    path = Path(value).expanduser()
+    if not path.is_absolute():
+        path = (PROJECT_ROOT / path).resolve()
+    else:
+        path = path.resolve()
+    return path
+
+
+
+def _require_bool(value: Any, field_name: str) -> bool:
+    if not isinstance(value, bool):
+        raise ValueError(f"Config field '{field_name}' must be a boolean.")
+    return value
+
+
+
+def main() -> int:
+    args = parse_args()
+
+    try:
+        config, config_path = load_runtime_config(args.config)
+        print(f"Loaded config from {config_path}")
+        saved_paths = run_feature_encoding(config, methods=args.method)
+        print(f"BoW encoding completed. Saved {len(saved_paths)} artifact(s).")
+        return 0
+    except (FileNotFoundError, NotADirectoryError, ValueError, OSError, ImportError, RuntimeError, TypeError) as exc:
+        print(f"BoW encoding failed: {exc}")
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/encoding/__init__.py
+++ b/src/encoding/__init__.py
@@ -1,3 +1,10 @@
+from .bow import (
+    assign_visual_words,
+    encode_bow_from_feature_path,
+    encode_bow_from_feature_record,
+    encode_bow_from_input,
+    encode_feature_directory,
+)
 from .codebook import CodebookArtifact, load_codebook_artifact, save_codebook_artifact, train_codebook
 from .io import (
     build_encoding_input_from_feature_record,
@@ -5,19 +12,28 @@ from .io import (
     load_feature_npz,
 )
 from .sampling import DescriptorSample, iter_feature_paths, sample_descriptors_by_method
+from .storage import EncodedFeatureResult, load_encoded_feature, save_encoded_feature
 from .types import EncodingInput, FeatureFileRecord
 
 __all__ = [
     "CodebookArtifact",
     "DescriptorSample",
+    "EncodedFeatureResult",
     "EncodingInput",
     "FeatureFileRecord",
+    "assign_visual_words",
     "build_encoding_input_from_feature_record",
     "build_encoding_input_from_local_feature",
+    "encode_bow_from_feature_path",
+    "encode_bow_from_feature_record",
+    "encode_bow_from_input",
+    "encode_feature_directory",
     "iter_feature_paths",
     "load_codebook_artifact",
+    "load_encoded_feature",
     "load_feature_npz",
     "sample_descriptors_by_method",
     "save_codebook_artifact",
+    "save_encoded_feature",
     "train_codebook",
 ]

--- a/src/encoding/bow.py
+++ b/src/encoding/bow.py
@@ -1,0 +1,227 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable
+
+import numpy as np
+from sklearn.metrics import pairwise_distances_argmin
+
+from .codebook import CodebookArtifact, load_codebook_artifact
+from .io import _normalize_method, build_encoding_input_from_feature_record, load_feature_npz
+from .sampling import iter_feature_paths
+from .storage import EncodedFeatureResult, save_encoded_feature
+from .types import EncodingInput, FeatureFileRecord
+
+
+
+def encode_bow_from_input(
+    encoding_input: EncodingInput,
+    codebook: CodebookArtifact,
+    *,
+    normalize: bool = False,
+    codebook_path: str | Path | None = None,
+) -> EncodedFeatureResult:
+    """Encode one validated encoding input into a BoW histogram."""
+    if not isinstance(encoding_input, EncodingInput):
+        raise TypeError(
+            "BoW encoding input must be an EncodingInput, "
+            f"got {type(encoding_input).__name__}."
+        )
+
+    _validate_input_and_codebook(encoding_input, codebook, "encode_bow_from_input")
+    resolved_codebook_path = _normalize_optional_codebook_path(codebook_path)
+    histogram_dtype = np.float32 if normalize else np.int32
+    histogram = np.zeros(codebook.n_clusters, dtype=histogram_dtype)
+
+    if encoding_input.descriptors_present and encoding_input.descriptors is not None:
+        visual_words = assign_visual_words(encoding_input.descriptors, codebook)
+        counts = np.bincount(visual_words, minlength=codebook.n_clusters)
+        if normalize:
+            histogram = counts.astype(np.float32, copy=False)
+            total = float(histogram.sum())
+            if total > 0.0:
+                histogram /= total
+        else:
+            histogram = counts.astype(np.int32, copy=False)
+
+    return EncodedFeatureResult(
+        sample_id=encoding_input.sample_id,
+        method=encoding_input.method,
+        encoding_type="bow",
+        num_visual_words=codebook.n_clusters,
+        histogram=histogram,
+        histogram_dtype=str(histogram.dtype),
+        num_descriptors=encoding_input.num_descriptors,
+        descriptors_present=encoding_input.descriptors_present,
+        codebook_path=resolved_codebook_path,
+        normalized=bool(normalize),
+    )
+
+
+
+def encode_bow_from_feature_record(
+    record: FeatureFileRecord,
+    codebook: CodebookArtifact,
+    *,
+    normalize: bool = False,
+    codebook_path: str | Path | None = None,
+) -> EncodedFeatureResult:
+    """Encode one validated feature-file record into a BoW histogram."""
+    encoding_input = build_encoding_input_from_feature_record(record)
+    return encode_bow_from_input(
+        encoding_input,
+        codebook,
+        normalize=normalize,
+        codebook_path=codebook_path,
+    )
+
+
+
+def encode_bow_from_feature_path(
+    feature_path: str | Path,
+    codebook: CodebookArtifact,
+    *,
+    normalize: bool = False,
+    codebook_path: str | Path | None = None,
+) -> EncodedFeatureResult:
+    """Load a feature artifact and encode it into a BoW histogram."""
+    record = load_feature_npz(feature_path)
+    return encode_bow_from_feature_record(
+        record,
+        codebook,
+        normalize=normalize,
+        codebook_path=codebook_path,
+    )
+
+
+
+def assign_visual_words(descriptors: np.ndarray, codebook: CodebookArtifact) -> np.ndarray:
+    """Assign each descriptor to its nearest visual word index."""
+    if not isinstance(descriptors, np.ndarray):
+        raise TypeError(f"Descriptors must be a numpy.ndarray, got {type(descriptors).__name__}.")
+    if descriptors.ndim != 2:
+        raise ValueError(f"Descriptors must be a 2D array, got shape={descriptors.shape}.")
+    if descriptors.shape[0] == 0:
+        return np.empty((0,), dtype=np.int32)
+    if descriptors.shape[1] != codebook.descriptor_dim:
+        raise ValueError(
+            f"Descriptor dimension {descriptors.shape[1]} does not match codebook descriptor_dim={codebook.descriptor_dim}."
+        )
+
+    descriptor_matrix = descriptors.astype(np.float32, copy=False)
+    assignments = pairwise_distances_argmin(descriptor_matrix, codebook.cluster_centers, metric="euclidean")
+    return np.asarray(assignments, dtype=np.int32)
+
+
+
+def encode_feature_directory(
+    feature_dir: str | Path,
+    codebook_dir: str | Path,
+    output_dir: str | Path,
+    *,
+    normalize: bool = False,
+    methods: Iterable[str] | None = None,
+) -> list[Path]:
+    """Batch-encode saved feature artifacts with method-matched codebooks."""
+    allowed_methods = _normalize_method_filter(methods)
+    codebooks = _load_codebooks_by_method(codebook_dir, allowed_methods)
+    if allowed_methods is not None:
+        missing_methods = sorted(method for method in allowed_methods if method not in codebooks)
+        if missing_methods:
+            raise FileNotFoundError(
+                f"Missing codebook artifact(s) for method(s): {', '.join(missing_methods)} under {Path(codebook_dir).expanduser()}."
+            )
+
+    saved_paths: list[Path] = []
+    matched_feature_count = 0
+    for feature_path in iter_feature_paths(feature_dir):
+        record = load_feature_npz(feature_path)
+        method = record.method
+        if allowed_methods is not None and method not in allowed_methods:
+            continue
+
+        matched_feature_count += 1
+        codebook_entry = codebooks.get(method)
+        if codebook_entry is None:
+            raise FileNotFoundError(
+                f"No codebook artifact available for method {method} under {Path(codebook_dir).expanduser()}."
+            )
+
+        codebook, codebook_path = codebook_entry
+        encoded_result = encode_bow_from_feature_record(
+            record,
+            codebook,
+            normalize=normalize,
+            codebook_path=codebook_path,
+        )
+        saved_paths.append(save_encoded_feature(encoded_result, output_dir))
+
+    if matched_feature_count == 0:
+        requested = "all methods" if allowed_methods is None else ", ".join(allowed_methods)
+        raise ValueError(f"No feature artifacts matched for {requested} under {Path(feature_dir).expanduser()}.")
+
+    return saved_paths
+
+
+
+def _validate_input_and_codebook(encoding_input: EncodingInput, codebook: CodebookArtifact, source: str) -> None:
+    if not isinstance(codebook, CodebookArtifact):
+        raise TypeError(f"{source}: codebook must be a CodebookArtifact, got {type(codebook).__name__}.")
+
+    method = _normalize_method(encoding_input.method)
+    if method != codebook.method:
+        raise ValueError(
+            f"{source}: encoding method {method} does not match codebook method {codebook.method}."
+        )
+    if encoding_input.descriptor_dim != codebook.descriptor_dim:
+        raise ValueError(
+            f"{source}: descriptor_dim {encoding_input.descriptor_dim} does not match codebook descriptor_dim {codebook.descriptor_dim}."
+        )
+    if encoding_input.descriptor_dtype != codebook.descriptor_dtype:
+        raise ValueError(
+            f"{source}: descriptor_dtype {encoding_input.descriptor_dtype!r} does not match codebook descriptor_dtype {codebook.descriptor_dtype!r}."
+        )
+
+
+
+def _normalize_optional_codebook_path(codebook_path: str | Path | None) -> str | None:
+    if codebook_path is None:
+        return None
+    path = Path(codebook_path).expanduser()
+    return path.as_posix()
+
+
+
+def _normalize_method_filter(methods: Iterable[str] | None) -> tuple[str, ...] | None:
+    if methods is None:
+        return None
+    normalized = [_normalize_method(method) for method in methods]
+    return tuple(sorted(set(normalized)))
+
+
+
+def _load_codebooks_by_method(
+    codebook_dir: str | Path,
+    methods: tuple[str, ...] | None = None,
+) -> dict[str, tuple[CodebookArtifact, Path]]:
+    resolved_dir = Path(codebook_dir).expanduser()
+    if not resolved_dir.exists():
+        raise FileNotFoundError(f"Codebook directory not found: {resolved_dir}")
+    if not resolved_dir.is_dir():
+        raise NotADirectoryError(f"Codebook path is not a directory: {resolved_dir}")
+
+    loaded: dict[str, tuple[CodebookArtifact, Path]] = {}
+    for codebook_path in sorted(path for path in resolved_dir.glob("*.npz") if path.is_file()):
+        artifact = load_codebook_artifact(codebook_path)
+        if methods is not None and artifact.method not in methods:
+            continue
+        if artifact.method in loaded:
+            previous_path = loaded[artifact.method][1]
+            raise ValueError(
+                f"Multiple codebook artifacts found for method {artifact.method}: {previous_path} and {codebook_path}."
+            )
+        loaded[artifact.method] = (artifact, codebook_path.resolve())
+
+    return loaded
+
+

--- a/src/encoding/storage.py
+++ b/src/encoding/storage.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+from numpy.lib.npyio import NpzFile
+
+from .io import _normalize_method
+
+
+_REQUIRED_ENCODED_KEYS = (
+    "sample_id",
+    "method",
+    "encoding_type",
+    "num_visual_words",
+    "histogram",
+    "histogram_dtype",
+    "num_descriptors",
+    "descriptors_present",
+    "codebook_path",
+    "normalized",
+)
+
+
+@dataclass(slots=True)
+class EncodedFeatureResult:
+    """Stable persisted representation for one encoded BoW feature."""
+
+    sample_id: str | None
+    method: str
+    encoding_type: str
+    num_visual_words: int
+    histogram: np.ndarray
+    histogram_dtype: str
+    num_descriptors: int
+    descriptors_present: bool
+    codebook_path: str | None
+    normalized: bool = False
+
+
+
+def save_encoded_feature(encoded_feature: EncodedFeatureResult, output_dir: str | Path) -> Path:
+    """Save one encoded feature artifact as a compressed `.npz` file."""
+    _validate_encoded_feature(encoded_feature, "save_encoded_feature")
+    if encoded_feature.sample_id is None:
+        raise ValueError("save_encoded_feature: sample_id must be provided for persistence.")
+
+    target_dir = Path(output_dir).expanduser().resolve()
+    target_dir.mkdir(parents=True, exist_ok=True)
+    save_path = target_dir / f"{_make_safe_encoded_name(encoded_feature.sample_id)}.npz"
+
+    np.savez_compressed(
+        save_path,
+        sample_id=np.array(encoded_feature.sample_id),
+        method=np.array(encoded_feature.method),
+        encoding_type=np.array(encoded_feature.encoding_type),
+        num_visual_words=np.array(encoded_feature.num_visual_words, dtype=np.int32),
+        histogram=np.asarray(encoded_feature.histogram),
+        histogram_dtype=np.array(encoded_feature.histogram_dtype),
+        num_descriptors=np.array(encoded_feature.num_descriptors, dtype=np.int32),
+        descriptors_present=np.array(int(encoded_feature.descriptors_present), dtype=np.uint8),
+        codebook_path=np.array(encoded_feature.codebook_path or ""),
+        normalized=np.array(int(encoded_feature.normalized), dtype=np.uint8),
+    )
+    return save_path
+
+
+
+def load_encoded_feature(encoded_path: str | Path) -> EncodedFeatureResult:
+    """Load and validate one saved encoded feature artifact."""
+    resolved_path = Path(encoded_path).expanduser()
+    if not resolved_path.exists():
+        raise FileNotFoundError(f"Encoded feature artifact not found: {resolved_path}")
+    if not resolved_path.is_file():
+        raise FileNotFoundError(f"Encoded feature path is not a file: {resolved_path}")
+
+    with np.load(resolved_path, allow_pickle=False) as data:
+        _validate_required_keys(data, resolved_path)
+        result = EncodedFeatureResult(
+            sample_id=_read_optional_string(data, "sample_id", resolved_path),
+            method=_normalize_method(_read_required_string(data, "method", resolved_path)),
+            encoding_type=_read_required_string(data, "encoding_type", resolved_path),
+            num_visual_words=_read_non_negative_int(data, "num_visual_words", resolved_path),
+            histogram=np.array(data["histogram"], copy=True),
+            histogram_dtype=_read_required_string(data, "histogram_dtype", resolved_path),
+            num_descriptors=_read_non_negative_int(data, "num_descriptors", resolved_path),
+            descriptors_present=_read_required_flag(data, "descriptors_present", resolved_path),
+            codebook_path=_read_optional_string(data, "codebook_path", resolved_path),
+            normalized=_read_required_flag(data, "normalized", resolved_path),
+        )
+
+    _validate_encoded_feature(result, resolved_path)
+    return result
+
+
+
+def _validate_encoded_feature(encoded_feature: EncodedFeatureResult, source: Any) -> None:
+    if not isinstance(encoded_feature, EncodedFeatureResult):
+        raise TypeError(
+            f"{source}: encoded_feature must be an EncodedFeatureResult, got {type(encoded_feature).__name__}."
+        )
+
+    if encoded_feature.sample_id is not None:
+        if not isinstance(encoded_feature.sample_id, str) or not encoded_feature.sample_id.strip():
+            raise ValueError(f"{source}: sample_id must be a non-empty string when provided.")
+        encoded_feature.sample_id = encoded_feature.sample_id.strip()
+
+    encoded_feature.method = _normalize_method(encoded_feature.method)
+    if encoded_feature.encoding_type != "bow":
+        raise ValueError(f"{source}: encoding_type must be 'bow', got {encoded_feature.encoding_type!r}.")
+    encoded_feature.num_visual_words = _require_non_negative_int(encoded_feature.num_visual_words, "num_visual_words")
+    encoded_feature.num_descriptors = _require_non_negative_int(encoded_feature.num_descriptors, "num_descriptors")
+    encoded_feature.descriptors_present = bool(encoded_feature.descriptors_present)
+    encoded_feature.normalized = bool(encoded_feature.normalized)
+
+    histogram = encoded_feature.histogram
+    if not isinstance(histogram, np.ndarray):
+        raise TypeError(f"{source}: histogram must be a numpy.ndarray, got {type(histogram).__name__}.")
+    if histogram.ndim != 1:
+        raise ValueError(f"{source}: histogram must be a 1D array, got shape={histogram.shape}.")
+    if histogram.shape[0] != encoded_feature.num_visual_words:
+        raise ValueError(
+            f"{source}: histogram length {histogram.shape[0]} does not match num_visual_words={encoded_feature.num_visual_words}."
+        )
+
+    actual_dtype = str(histogram.dtype)
+    if encoded_feature.histogram_dtype != actual_dtype:
+        raise ValueError(
+            f"{source}: histogram_dtype {encoded_feature.histogram_dtype!r} does not match histogram dtype {actual_dtype!r}."
+        )
+
+    if encoded_feature.normalized:
+        if actual_dtype != "float32":
+            raise ValueError(f"{source}: normalized BoW histograms must use dtype float32, got {actual_dtype}.")
+    else:
+        if actual_dtype != "int32":
+            raise ValueError(f"{source}: raw-count BoW histograms must use dtype int32, got {actual_dtype}.")
+
+    if encoded_feature.codebook_path is not None:
+        if not isinstance(encoded_feature.codebook_path, str) or not encoded_feature.codebook_path.strip():
+            raise ValueError(f"{source}: codebook_path must be a non-empty string when provided.")
+        encoded_feature.codebook_path = Path(encoded_feature.codebook_path).expanduser().as_posix()
+
+
+
+def _validate_required_keys(data: NpzFile, source: Path) -> None:
+    missing_keys = [key for key in _REQUIRED_ENCODED_KEYS if key not in data.files]
+    if missing_keys:
+        raise ValueError(f"{source}: missing required encoded feature keys: {', '.join(missing_keys)}.")
+
+
+
+def _read_required_string(data: NpzFile, key: str, source: Any) -> str:
+    value = data[key]
+    if value.ndim != 0:
+        raise ValueError(f"{source}: key '{key}' must be a scalar string value.")
+    scalar = value.item()
+    if not isinstance(scalar, str) or not scalar.strip():
+        raise ValueError(f"{source}: key '{key}' must be a non-empty string.")
+    return scalar.strip()
+
+
+
+def _read_optional_string(data: NpzFile, key: str, source: Any) -> str | None:
+    value = data[key]
+    if value.ndim != 0:
+        raise ValueError(f"{source}: key '{key}' must be a scalar string value.")
+    scalar = value.item()
+    if not isinstance(scalar, str):
+        raise ValueError(f"{source}: key '{key}' must be a string value.")
+    stripped = scalar.strip()
+    return stripped or None
+
+
+
+def _read_non_negative_int(data: NpzFile, key: str, source: Any) -> int:
+    value = data[key]
+    if value.ndim != 0:
+        raise ValueError(f"{source}: key '{key}' must be a scalar integer value.")
+    return _require_non_negative_int(value.item(), key)
+
+
+
+def _read_required_flag(data: NpzFile, key: str, source: Any) -> bool:
+    parsed = _read_non_negative_int(data, key, source)
+    if parsed not in (0, 1):
+        raise ValueError(f"{source}: key '{key}' must be 0 or 1, got {parsed}.")
+    return bool(parsed)
+
+
+
+def _require_non_negative_int(value: Any, field_name: str) -> int:
+    if isinstance(value, bool):
+        raise ValueError(f"{field_name} must be a non-negative integer.")
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{field_name} must be a non-negative integer.") from exc
+    if parsed < 0:
+        raise ValueError(f"{field_name} must be non-negative, got {parsed}.")
+    return parsed
+
+
+
+def _make_safe_encoded_name(sample_id: str) -> str:
+    normalized = sample_id.replace("\\", "/")
+    normalized = re.sub(r"[^A-Za-z0-9._-]+", "__", normalized)
+    normalized = normalized.strip("._")
+    return normalized or "encoded"
+

--- a/tests/test_bow.py
+++ b/tests/test_bow.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+import shutil
+import unittest
+import uuid
+from pathlib import Path
+
+import numpy as np
+
+from src.encoding import (
+    CodebookArtifact,
+    EncodingInput,
+    encode_bow_from_input,
+    load_encoded_feature,
+    save_encoded_feature,
+)
+
+
+class BowTests(unittest.TestCase):
+    def test_bow_encoding_sift_descriptors(self) -> None:
+        codebook = self._make_sift_codebook()
+        encoding_input = EncodingInput(
+            sample_id="sample/sift.jpg",
+            method="SIFT",
+            descriptors=np.vstack([
+                np.zeros((2, 128), dtype=np.float32),
+                np.full((3, 128), 10.0, dtype=np.float32),
+            ]),
+            descriptors_present=True,
+            descriptor_shape=(5, 128),
+            descriptor_dtype="float32",
+            descriptor_dim=128,
+            num_descriptors=5,
+        )
+
+        result = encode_bow_from_input(encoding_input, codebook, normalize=False)
+
+        self.assertEqual(result.method, "SIFT")
+        self.assertEqual(result.encoding_type, "bow")
+        self.assertEqual(result.num_visual_words, 2)
+        self.assertEqual(result.histogram.tolist(), [2, 3])
+        self.assertEqual(result.histogram_dtype, "int32")
+        self.assertEqual(result.num_descriptors, 5)
+        self.assertTrue(result.descriptors_present)
+
+    def test_bow_encoding_orb_descriptors(self) -> None:
+        codebook = self._make_orb_codebook()
+        encoding_input = EncodingInput(
+            sample_id="sample/orb.jpg",
+            method="ORB",
+            descriptors=np.vstack([
+                np.zeros((1, 32), dtype=np.uint8),
+                np.full((4, 32), 255, dtype=np.uint8),
+            ]),
+            descriptors_present=True,
+            descriptor_shape=(5, 32),
+            descriptor_dtype="uint8",
+            descriptor_dim=32,
+            num_descriptors=5,
+        )
+
+        result = encode_bow_from_input(encoding_input, codebook, normalize=False)
+
+        self.assertEqual(result.method, "ORB")
+        self.assertEqual(result.histogram.tolist(), [1, 4])
+        self.assertEqual(result.histogram_dtype, "int32")
+
+    def test_empty_descriptors_produce_zero_histogram(self) -> None:
+        codebook = self._make_sift_codebook()
+        encoding_input = EncodingInput(
+            sample_id="sample/empty.jpg",
+            method="SIFT",
+            descriptors=None,
+            descriptors_present=False,
+            descriptor_shape=(0, 128),
+            descriptor_dtype="float32",
+            descriptor_dim=128,
+            num_descriptors=0,
+        )
+
+        result = encode_bow_from_input(encoding_input, codebook, normalize=False)
+
+        self.assertEqual(result.histogram.tolist(), [0, 0])
+        self.assertEqual(result.num_visual_words, 2)
+        self.assertFalse(result.descriptors_present)
+        self.assertEqual(result.num_descriptors, 0)
+
+    def test_mismatched_method_raises(self) -> None:
+        encoding_input = EncodingInput(
+            sample_id="sample/mismatch.jpg",
+            method="SIFT",
+            descriptors=np.ones((1, 128), dtype=np.float32),
+            descriptors_present=True,
+            descriptor_shape=(1, 128),
+            descriptor_dtype="float32",
+            descriptor_dim=128,
+            num_descriptors=1,
+        )
+
+        with self.assertRaises(ValueError):
+            encode_bow_from_input(encoding_input, self._make_orb_codebook())
+
+    def test_mismatched_descriptor_dim_raises(self) -> None:
+        encoding_input = EncodingInput(
+            sample_id="sample/bad_dim.jpg",
+            method="SIFT",
+            descriptors=np.ones((1, 64), dtype=np.float32),
+            descriptors_present=True,
+            descriptor_shape=(1, 64),
+            descriptor_dtype="float32",
+            descriptor_dim=64,
+            num_descriptors=1,
+        )
+
+        with self.assertRaises(ValueError):
+            encode_bow_from_input(encoding_input, self._make_sift_codebook())
+
+    def test_encoded_artifact_roundtrip(self) -> None:
+        output_dir = self._make_temp_dir()
+        codebook = self._make_sift_codebook()
+        encoding_input = EncodingInput(
+            sample_id="sample/roundtrip.jpg",
+            method="SIFT",
+            descriptors=np.vstack([
+                np.zeros((1, 128), dtype=np.float32),
+                np.full((1, 128), 10.0, dtype=np.float32),
+            ]),
+            descriptors_present=True,
+            descriptor_shape=(2, 128),
+            descriptor_dtype="float32",
+            descriptor_dim=128,
+            num_descriptors=2,
+        )
+
+        result = encode_bow_from_input(
+            encoding_input,
+            codebook,
+            normalize=False,
+            codebook_path="outputs/indices/codebooks/codebook_sift_k2_minibatch_kmeans.npz",
+        )
+        save_path = save_encoded_feature(result, output_dir)
+        loaded = load_encoded_feature(save_path)
+
+        self.assertEqual(loaded.sample_id, "sample/roundtrip.jpg")
+        self.assertEqual(loaded.method, "SIFT")
+        self.assertEqual(loaded.encoding_type, "bow")
+        self.assertEqual(loaded.num_visual_words, 2)
+        self.assertEqual(loaded.histogram.tolist(), [1, 1])
+        self.assertEqual(loaded.histogram_dtype, "int32")
+        self.assertTrue(loaded.descriptors_present)
+        self.assertEqual(loaded.num_descriptors, 2)
+        self.assertEqual(
+            loaded.codebook_path,
+            "outputs/indices/codebooks/codebook_sift_k2_minibatch_kmeans.npz",
+        )
+
+    def _make_temp_dir(self) -> Path:
+        root = Path("outputs") / "encoded" / "test_tmp"
+        root.mkdir(parents=True, exist_ok=True)
+        temp_dir = root / uuid.uuid4().hex
+        temp_dir.mkdir(parents=True, exist_ok=True)
+        self.addCleanup(lambda: shutil.rmtree(temp_dir, ignore_errors=True))
+        return temp_dir
+
+    def _make_sift_codebook(self) -> CodebookArtifact:
+        return CodebookArtifact(
+            method="SIFT",
+            trainer="minibatch_kmeans",
+            n_clusters=2,
+            descriptor_dim=128,
+            descriptor_dtype="float32",
+            training_descriptor_count=2,
+            random_state=0,
+            batch_size=2,
+            cluster_centers=np.vstack([
+                np.zeros((1, 128), dtype=np.float32),
+                np.full((1, 128), 10.0, dtype=np.float32),
+            ]),
+        )
+
+    def _make_orb_codebook(self) -> CodebookArtifact:
+        return CodebookArtifact(
+            method="ORB",
+            trainer="minibatch_kmeans",
+            n_clusters=2,
+            descriptor_dim=32,
+            descriptor_dtype="uint8",
+            training_descriptor_count=2,
+            random_state=0,
+            batch_size=2,
+            cluster_centers=np.vstack([
+                np.zeros((1, 32), dtype=np.float32),
+                np.full((1, 32), 255.0, dtype=np.float32),
+            ]),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
What:
- add `src/encoding/bow.py` for method-aware visual word assignment, BoW histogram construction, and batch offline encoding from saved feature artifacts
- add `src/encoding/storage.py` for stable encoded feature save/load helpers and persist encoded outputs under `outputs/encoded/*.npz`
- add `scripts/encode_features.py`, extend `configs/base.yaml` with `encoding.bow`, and add focused tests for BoW encoding, empty inputs, mismatch validation, and artifact roundtrip

Why:
- provide the next minimal encoding-stage output after reusable codebooks without changing the existing local feature or feature-file contracts
- make empty-descriptor samples explicitly encodable as valid zero histograms instead of skipping them silently
- prepare a stable persisted BoW representation for the later TF-IDF and indexing stages without introducing those stages yet