### PR TITLE
feat(scripts | stage4-4): integrate encoding stage hooks and offline batch entry

### DIFF
--- a/configs/base.yaml
+++ b/configs/base.yaml
@@ -34,6 +34,7 @@ encoding:
   enabled: false
   input:
     feature_dir: outputs/features
+    encoded_dir: outputs/encoded
   codebook:
     enabled: false
     output_dir: outputs/indices/codebooks
@@ -43,10 +44,8 @@ encoding:
     batch_size: 1024
     random_state: 42
   bow:
-    enabled: false
-    codebook_dir: outputs/indices/codebooks
-    output_dir: outputs/encoded
-    normalize: false
+    enabled: true
+    normalized: false
 
 output:
   feature_dir: outputs/features

--- a/docs/ai/feedback/stage4/feedback_stage4-4.md
+++ b/docs/ai/feedback/stage4/feedback_stage4-4.md
@@ -1,0 +1,86 @@
+# Issue 4.4 Feedback
+
+## Changed
+
+- `configs/base.yaml` now uses one normalized `encoding` structure with `input.feature_dir`, `input.encoded_dir`, `codebook.output_dir`, and `bow.normalized`.
+- `src/encoding/bow.py` now exposes `encode_feature_file(...)` so scripts can encode one saved feature artifact without duplicating method-matched codebook lookup and persistence logic.
+- `src/encoding/__init__.py` now exports the single-file encoding helper.
+- `scripts/run_pipeline.py` now has a minimal optional preview-time encoding hook that runs only when `encoding.enabled` is true.
+- `scripts/encode_features.py` now follows the normalized config structure while still accepting the Stage 4.3 legacy fields `encoding.bow.codebook_dir`, `encoding.bow.output_dir`, and `encoding.bow.normalize`.
+- `docs/design/encoding_usage.md` now documents codebook training, preview-time encoding, and offline batch encoding.
+- `tests/test_encoding_integration.py` now verifies the disabled preview path, the enabled preview path, the missing-codebook failure path, and offline batch compatibility with legacy Stage 4.3 config fields.
+
+## Integration Behavior
+
+The integration point remains intentionally small.
+
+`run_pipeline.py` behavior is now:
+
+- run the existing dataset load, preprocess, local feature extraction, feature save, and keypoint visualization flow
+- if `encoding.enabled` is false, stop there exactly as before
+- if `encoding.enabled` is true, encode the just-saved feature artifact with the matching method-specific codebook and save the BoW artifact
+
+This keeps encoding out of the earlier pipeline stages and avoids duplicating BoW logic inside the script.
+
+## Config Notes
+
+The normalized config shape is:
+
+```yaml
+encoding:
+  enabled: false
+  input:
+    feature_dir: outputs/features
+    encoded_dir: outputs/encoded
+  codebook:
+    enabled: false
+    output_dir: outputs/indices/codebooks
+    trainer: minibatch_kmeans
+    n_clusters: 256
+    max_descriptors: 50000
+    batch_size: 1024
+    random_state: 42
+  bow:
+    enabled: true
+    normalized: false
+```
+
+Compatibility behavior retained in code:
+
+- `scripts/encode_features.py` still accepts `encoding.bow.codebook_dir`
+- `scripts/encode_features.py` still accepts `encoding.bow.output_dir`
+- both preview-time and batch encoding still accept `encoding.bow.normalize`
+
+## Validation
+
+Automated validation:
+
+- `python -m unittest discover -s tests -p "test_*.py" -v`
+
+Observed coverage:
+
+- default preview path stays inactive when encoding is disabled
+- preview-time encoding writes an encoded artifact when the codebook is available
+- preview-time encoding fails clearly when the codebook is missing
+- offline batch encoding still works with legacy Stage 4.3 config fields
+- existing Stage 4.1 to 4.3 tests still pass unchanged
+
+Manual verification completed:
+
+- `python scripts/train_codebook.py --config outputs/logs/stage4_4_verify/train_codebook_stage44.yaml --method sift`
+- `python scripts/encode_features.py --config outputs/logs/stage4_4_verify/encode_features_stage44.yaml --method sift`
+- one real saved SIFT feature artifact was also encoded through `scripts.run_pipeline.maybe_encode_saved_feature(...)`
+
+Observed environment note:
+
+- `joblib/loky` emits a physical-core detection warning in this sandbox, but training and encoding still complete successfully
+
+## Acceptance Alignment
+
+This issue now satisfies the intended Stage 4.4 scope because:
+
+- the encoding stage is integrated into `run_pipeline.py` behind a config-gated, least-invasive hook
+- default preview behavior remains unchanged when encoding is disabled
+- the offline batch entry remains the main full-dataset encoding path
+- config usage is regularized without breaking the Stage 4.3 field names in code
+- no TF-IDF, indexing, retrieval, or new encoding algorithms were introduced

--- a/docs/design/encoding_usage.md
+++ b/docs/design/encoding_usage.md
@@ -1,0 +1,87 @@
+# Encoding Stage Usage
+
+This note covers the current Stage 4 encoding entrypoints.
+
+## Config Shape
+
+The active config lives under `encoding` in `configs/base.yaml`:
+
+```yaml
+encoding:
+  enabled: false
+  input:
+    feature_dir: outputs/features
+    encoded_dir: outputs/encoded
+  codebook:
+    enabled: false
+    output_dir: outputs/indices/codebooks
+    trainer: minibatch_kmeans
+    n_clusters: 256
+    max_descriptors: 50000
+    batch_size: 1024
+    random_state: 42
+  bow:
+    enabled: true
+    normalized: false
+```
+
+Notes:
+
+- `encoding.enabled` controls the optional preview-time hook in `scripts/run_pipeline.py`.
+- `encoding.codebook.enabled` controls whether `scripts/train_codebook.py` is allowed to run.
+- `encoding.bow.enabled` controls whether `scripts/encode_features.py` is allowed to run.
+- `encoding.input.encoded_dir` is the default save location for encoded BoW artifacts.
+- Legacy Stage 4.3 fields `encoding.bow.codebook_dir`, `encoding.bow.output_dir`, and `encoding.bow.normalize` are still accepted for compatibility.
+
+## 1. Train Codebooks
+
+Enable codebook training in a config copy, then run:
+
+```bash
+python scripts/train_codebook.py --config path/to/codebook_config.yaml
+```
+
+Expected inputs and outputs:
+
+- reads local feature artifacts from `encoding.input.feature_dir`
+- writes method-specific codebooks to `encoding.codebook.output_dir`
+
+## 2. Preview-Time Encoding From `run_pipeline.py`
+
+To encode each preview sample right after its feature artifact is saved:
+
+1. set `encoding.enabled: true`
+2. keep `encoding.bow.enabled: true`
+3. point `encoding.codebook.output_dir` to a directory that already contains the matching method-specific codebook
+
+Then run:
+
+```bash
+python scripts/run_pipeline.py --config path/to/preview_encoding_config.yaml
+```
+
+Behavior:
+
+- when `encoding.enabled` is `false`, `run_pipeline.py` behaves as before
+- when `encoding.enabled` is `true`, the script encodes the just-saved feature artifact and writes the BoW result to `encoding.input.encoded_dir`
+- if the matching codebook is missing, the run fails with a clear error instead of skipping encoding silently
+
+## 3. Offline Batch Encoding
+
+To encode an existing feature directory in batch:
+
+```bash
+python scripts/encode_features.py --config path/to/encoding_config.yaml
+```
+
+Optional method filters are supported:
+
+```bash
+python scripts/encode_features.py --config path/to/encoding_config.yaml --method sift --method orb
+```
+
+Behavior:
+
+- reads saved feature artifacts from `encoding.input.feature_dir`
+- loads the matching method-specific codebook from `encoding.codebook.output_dir`
+- writes encoded BoW artifacts to `encoding.input.encoded_dir`

--- a/scripts/encode_features.py
+++ b/scripts/encode_features.py
@@ -54,18 +54,21 @@ def run_feature_encoding(config: dict[str, Any], methods: list[str] | None = Non
         raise ValueError("Config field 'encoding.bow.enabled' must be true to encode features.")
 
     feature_dir = _resolve_path(
-        input_config.get("feature_dir", output_config.get("feature_dir", "outputs/features")),
+        _first_value(input_config.get("feature_dir"), output_config.get("feature_dir"), "outputs/features"),
         "encoding.input.feature_dir",
     )
     codebook_dir = _resolve_path(
-        bow_config.get("codebook_dir", codebook_config.get("output_dir", "outputs/indices/codebooks")),
-        "encoding.bow.codebook_dir",
+        _first_value(codebook_config.get("output_dir"), bow_config.get("codebook_dir"), "outputs/indices/codebooks"),
+        "encoding.codebook.output_dir",
     )
     encoded_dir = _resolve_path(
-        bow_config.get("output_dir", "outputs/encoded"),
-        "encoding.bow.output_dir",
+        _first_value(input_config.get("encoded_dir"), bow_config.get("output_dir"), "outputs/encoded"),
+        "encoding.input.encoded_dir",
     )
-    normalize = _require_bool(bow_config.get("normalize", False), "encoding.bow.normalize")
+    normalize = _resolve_bow_normalized(bow_config)
+
+    print(f"Encoding saved feature artifacts from {feature_dir} into {encoded_dir}")
+    print(f"Using method-specific codebooks from {codebook_dir}")
 
     saved_paths = encode_feature_directory(
         feature_dir=feature_dir,
@@ -111,6 +114,23 @@ def _resolve_path(value: Any, field_name: str) -> Path:
     else:
         path = path.resolve()
     return path
+
+
+
+def _resolve_bow_normalized(bow_config: dict[str, Any]) -> bool:
+    if "normalized" in bow_config:
+        return _require_bool(bow_config.get("normalized"), "encoding.bow.normalized")
+    if "normalize" in bow_config:
+        return _require_bool(bow_config.get("normalize"), "encoding.bow.normalize")
+    return False
+
+
+
+def _first_value(*values: Any) -> Any:
+    for value in values:
+        if value is not None:
+            return value
+    return None
 
 
 

--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -11,6 +11,7 @@ if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
 from src.datasets import ImageDatasetLoader, ImageSample
+from src.encoding import encode_feature_file
 from src.features.local import LocalFeatureResult, extract_local_features, save_local_feature_result
 from src.preprocess import PreprocessResult, preprocess_image
 from src.utils import get_default_config_path, load_config
@@ -116,6 +117,7 @@ def run_pipeline_skeleton(loader: ImageDatasetLoader, config: dict[str, Any]) ->
     local_feature_config = _get_local_feature_config(config)
     visualization_config = _get_visualization_config(config)
     output_config = _get_mapping(config, "output")
+    preview_encoding_enabled = _is_preview_encoding_enabled(config)
     sample_limit = min(_resolve_max_samples(local_feature_config), len(loader))
     samples = loader.preview(sample_limit)
 
@@ -123,6 +125,8 @@ def run_pipeline_skeleton(loader: ImageDatasetLoader, config: dict[str, Any]) ->
     print(f"Local feature method: {str(local_feature_config.get('method', local_feature_config.get('local_method', 'sift'))).lower()}")
     if bool(visualization_config.get("enabled", True)) and bool(visualization_config.get("save_keypoints", True)):
         print("Keypoint visualization enabled")
+    if preview_encoding_enabled:
+        print("Preview-time BoW encoding enabled")
 
     for sample in samples:
         print(f"Sample: id={sample.sample_id} file={sample.file_name} split={sample.split}")
@@ -153,8 +157,12 @@ def run_pipeline_skeleton(loader: ImageDatasetLoader, config: dict[str, Any]) ->
             )
             print(f"Saved keypoint figure to {figure_path}")
 
-        # Future hooks: feature encoding -> tf-idf -> inverted index -> retrieval
-        # -> rerank -> query expansion -> dense global retrieval -> hybrid fusion
+        encoded_path = maybe_encode_saved_feature(save_path, config)
+        if encoded_path is not None:
+            print(f"Saved encoded feature to {encoded_path}")
+
+        # Future hooks: tf-idf -> inverted index -> retrieval -> rerank
+        # -> query expansion -> dense global retrieval -> hybrid fusion
 
 
 
@@ -223,6 +231,33 @@ def visualize_keypoints(
 
 
 
+def maybe_encode_saved_feature(feature_path: Path | None, config: dict[str, Any]) -> Path | None:
+    encoding_config = _get_mapping(config, "encoding")
+    if not bool(encoding_config.get("enabled", False)):
+        return None
+
+    if feature_path is None:
+        raise ValueError(
+            "Encoding is enabled but no feature artifact was saved. "
+            "Preview-time encoding requires local_feature.save=true."
+        )
+
+    bow_config = _get_nested_mapping(encoding_config, "bow", "encoding.bow")
+    if not bool(bow_config.get("enabled", True)):
+        raise ValueError("Encoding is enabled but encoding.bow.enabled is false.")
+
+    codebook_dir = _resolve_encoding_codebook_dir(config)
+    encoded_dir = _resolve_encoding_output_dir(config)
+    normalize = _resolve_encoding_normalized(config)
+    return encode_feature_file(
+        feature_path=feature_path,
+        codebook_dir=codebook_dir,
+        output_dir=encoded_dir,
+        normalize=normalize,
+    )
+
+
+
 def _get_local_feature_config(config: dict[str, Any]) -> dict[str, Any]:
     value = config.get("local_feature")
     if value is not None:
@@ -246,6 +281,45 @@ def _get_visualization_config(config: dict[str, Any]) -> dict[str, Any]:
     if not isinstance(value, dict):
         raise ValueError("Config section 'visualization' must be a mapping.")
     return value
+
+
+
+def _is_preview_encoding_enabled(config: dict[str, Any]) -> bool:
+    encoding_config = _get_mapping(config, "encoding")
+    return bool(encoding_config.get("enabled", False))
+
+
+
+def _resolve_encoding_codebook_dir(config: dict[str, Any]) -> Path:
+    encoding_config = _get_mapping(config, "encoding")
+    codebook_config = _get_nested_mapping(encoding_config, "codebook", "encoding.codebook")
+    bow_config = _get_nested_mapping(encoding_config, "bow", "encoding.bow")
+    return _require_path(
+        _first_value(codebook_config.get("output_dir"), bow_config.get("codebook_dir"), "outputs/indices/codebooks"),
+        "encoding.codebook.output_dir",
+    )
+
+
+
+def _resolve_encoding_output_dir(config: dict[str, Any]) -> Path:
+    encoding_config = _get_mapping(config, "encoding")
+    input_config = _get_nested_mapping(encoding_config, "input", "encoding.input")
+    bow_config = _get_nested_mapping(encoding_config, "bow", "encoding.bow")
+    return _require_path(
+        _first_value(input_config.get("encoded_dir"), bow_config.get("output_dir"), "outputs/encoded"),
+        "encoding.input.encoded_dir",
+    )
+
+
+
+def _resolve_encoding_normalized(config: dict[str, Any]) -> bool:
+    encoding_config = _get_mapping(config, "encoding")
+    bow_config = _get_nested_mapping(encoding_config, "bow", "encoding.bow")
+    if "normalized" in bow_config:
+        return _require_bool(bow_config.get("normalized"), "encoding.bow.normalized")
+    if "normalize" in bow_config:
+        return _require_bool(bow_config.get("normalize"), "encoding.bow.normalize")
+    return False
 
 
 
@@ -284,6 +358,31 @@ def _get_mapping(config: dict[str, Any], key: str) -> dict[str, Any]:
         return {}
     if not isinstance(value, dict):
         raise ValueError(f"Config section '{key}' must be a mapping.")
+    return value
+
+
+
+def _get_nested_mapping(parent: dict[str, Any], key: str, field_name: str) -> dict[str, Any]:
+    value = parent.get(key)
+    if value is None:
+        return {}
+    if not isinstance(value, dict):
+        raise ValueError(f"Config section '{field_name}' must be a mapping.")
+    return value
+
+
+
+def _first_value(*values: Any) -> Any:
+    for value in values:
+        if value is not None:
+            return value
+    return None
+
+
+
+def _require_bool(value: Any, field_name: str) -> bool:
+    if not isinstance(value, bool):
+        raise ValueError(f"Config field '{field_name}' must be a boolean.")
     return value
 
 

--- a/src/encoding/__init__.py
+++ b/src/encoding/__init__.py
@@ -4,6 +4,7 @@ from .bow import (
     encode_bow_from_feature_record,
     encode_bow_from_input,
     encode_feature_directory,
+    encode_feature_file,
 )
 from .codebook import CodebookArtifact, load_codebook_artifact, save_codebook_artifact, train_codebook
 from .io import (
@@ -28,6 +29,7 @@ __all__ = [
     "encode_bow_from_feature_record",
     "encode_bow_from_input",
     "encode_feature_directory",
+    "encode_feature_file",
     "iter_feature_paths",
     "load_codebook_artifact",
     "load_encoded_feature",

--- a/src/encoding/bow.py
+++ b/src/encoding/bow.py
@@ -95,6 +95,26 @@ def encode_bow_from_feature_path(
 
 
 
+def encode_feature_file(
+    feature_path: str | Path,
+    codebook_dir: str | Path,
+    output_dir: str | Path,
+    *,
+    normalize: bool = False,
+) -> Path:
+    """Encode one saved feature artifact with its matching method-specific codebook."""
+    record = load_feature_npz(feature_path)
+    codebook, codebook_path = _load_required_codebook_for_method(codebook_dir, record.method)
+    encoded_result = encode_bow_from_feature_record(
+        record,
+        codebook,
+        normalize=normalize,
+        codebook_path=codebook_path,
+    )
+    return save_encoded_feature(encoded_result, output_dir)
+
+
+
 def assign_visual_words(descriptors: np.ndarray, codebook: CodebookArtifact) -> np.ndarray:
     """Assign each descriptor to its nearest visual word index."""
     if not isinstance(descriptors, np.ndarray):
@@ -141,13 +161,7 @@ def encode_feature_directory(
             continue
 
         matched_feature_count += 1
-        codebook_entry = codebooks.get(method)
-        if codebook_entry is None:
-            raise FileNotFoundError(
-                f"No codebook artifact available for method {method} under {Path(codebook_dir).expanduser()}."
-            )
-
-        codebook, codebook_path = codebook_entry
+        codebook, codebook_path = _require_codebook_entry(codebooks, method, codebook_dir)
         encoded_result = encode_bow_from_feature_record(
             record,
             codebook,
@@ -200,6 +214,30 @@ def _normalize_method_filter(methods: Iterable[str] | None) -> tuple[str, ...] |
 
 
 
+def _load_required_codebook_for_method(
+    codebook_dir: str | Path,
+    method: str,
+) -> tuple[CodebookArtifact, Path]:
+    normalized_method = _normalize_method(method)
+    codebooks = _load_codebooks_by_method(codebook_dir, methods=(normalized_method,))
+    return _require_codebook_entry(codebooks, normalized_method, codebook_dir)
+
+
+
+def _require_codebook_entry(
+    codebooks: dict[str, tuple[CodebookArtifact, Path]],
+    method: str,
+    codebook_dir: str | Path,
+) -> tuple[CodebookArtifact, Path]:
+    codebook_entry = codebooks.get(method)
+    if codebook_entry is None:
+        raise FileNotFoundError(
+            f"No codebook artifact available for method {method} under {Path(codebook_dir).expanduser()}."
+        )
+    return codebook_entry
+
+
+
 def _load_codebooks_by_method(
     codebook_dir: str | Path,
     methods: tuple[str, ...] | None = None,
@@ -223,5 +261,3 @@ def _load_codebooks_by_method(
         loaded[artifact.method] = (artifact, codebook_path.resolve())
 
     return loaded
-
-

--- a/tests/test_encoding_integration.py
+++ b/tests/test_encoding_integration.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+import shutil
+import unittest
+import uuid
+from pathlib import Path
+
+import numpy as np
+
+from scripts.encode_features import run_feature_encoding
+from scripts.run_pipeline import maybe_encode_saved_feature
+from src.encoding import CodebookArtifact, load_encoded_feature, save_codebook_artifact
+
+
+class EncodingIntegrationTests(unittest.TestCase):
+    def test_preview_encoding_disabled_keeps_default_path_inactive(self) -> None:
+        result = maybe_encode_saved_feature(None, {"encoding": {"enabled": False}})
+        self.assertIsNone(result)
+
+    def test_preview_encoding_enabled_saves_encoded_artifact(self) -> None:
+        workspace = self._make_workspace()
+        feature_path = self._write_feature_npz(
+            workspace / "features" / "preview_sift.npz",
+            method="SIFT",
+            descriptors=np.vstack([
+                np.zeros((1, 128), dtype=np.float32),
+                np.full((1, 128), 10.0, dtype=np.float32),
+            ]),
+        )
+        save_codebook_artifact(self._make_sift_codebook(), workspace / "codebooks")
+
+        encoded_path = maybe_encode_saved_feature(
+            feature_path,
+            {
+                "encoding": {
+                    "enabled": True,
+                    "input": {"encoded_dir": str(workspace / "encoded")},
+                    "codebook": {"output_dir": str(workspace / "codebooks")},
+                    "bow": {"enabled": True, "normalized": False},
+                }
+            },
+        )
+        loaded = load_encoded_feature(encoded_path)
+
+        self.assertTrue(encoded_path.is_file())
+        self.assertEqual(loaded.method, "SIFT")
+        self.assertEqual(loaded.num_visual_words, 2)
+        self.assertEqual(loaded.histogram.tolist(), [1, 1])
+        self.assertFalse(loaded.normalized)
+
+    def test_preview_encoding_missing_codebook_raises_clear_error(self) -> None:
+        workspace = self._make_workspace()
+        feature_path = self._write_feature_npz(
+            workspace / "features" / "missing_codebook.npz",
+            method="SIFT",
+            descriptors=np.ones((1, 128), dtype=np.float32),
+        )
+
+        with self.assertRaises(FileNotFoundError) as exc:
+            maybe_encode_saved_feature(
+                feature_path,
+                {
+                    "encoding": {
+                        "enabled": True,
+                        "input": {"encoded_dir": str(workspace / "encoded")},
+                        "codebook": {"output_dir": str(workspace / "codebooks")},
+                        "bow": {"enabled": True, "normalized": False},
+                    }
+                },
+            )
+
+        self.assertIn("No codebook artifact available", str(exc.exception))
+
+    def test_offline_batch_encoding_supports_stage43_legacy_fields(self) -> None:
+        workspace = self._make_workspace()
+        self._write_feature_npz(
+            workspace / "features" / "legacy_orb.npz",
+            method="ORB",
+            descriptors=np.vstack([
+                np.zeros((1, 32), dtype=np.uint8),
+                np.full((2, 32), 255, dtype=np.uint8),
+            ]),
+        )
+        save_codebook_artifact(self._make_orb_codebook(), workspace / "codebooks")
+
+        saved_paths = run_feature_encoding(
+            {
+                "encoding": {
+                    "input": {"feature_dir": str(workspace / "features")},
+                    "bow": {
+                        "enabled": True,
+                        "codebook_dir": str(workspace / "codebooks"),
+                        "output_dir": str(workspace / "encoded"),
+                        "normalize": False,
+                    },
+                },
+                "output": {},
+            }
+        )
+        loaded = load_encoded_feature(saved_paths[0])
+
+        self.assertEqual(len(saved_paths), 1)
+        self.assertEqual(loaded.method, "ORB")
+        self.assertEqual(loaded.histogram.tolist(), [1, 2])
+        self.assertEqual(loaded.histogram_dtype, "int32")
+
+    def _make_workspace(self) -> Path:
+        root = Path("outputs") / "logs" / "test_tmp" / uuid.uuid4().hex
+        (root / "features").mkdir(parents=True, exist_ok=True)
+        (root / "codebooks").mkdir(parents=True, exist_ok=True)
+        (root / "encoded").mkdir(parents=True, exist_ok=True)
+        self.addCleanup(lambda: shutil.rmtree(root, ignore_errors=True))
+        return root
+
+    def _make_sift_codebook(self) -> CodebookArtifact:
+        return CodebookArtifact(
+            method="SIFT",
+            trainer="minibatch_kmeans",
+            n_clusters=2,
+            descriptor_dim=128,
+            descriptor_dtype="float32",
+            training_descriptor_count=2,
+            random_state=0,
+            batch_size=2,
+            cluster_centers=np.vstack([
+                np.zeros((1, 128), dtype=np.float32),
+                np.full((1, 128), 10.0, dtype=np.float32),
+            ]),
+        )
+
+    def _make_orb_codebook(self) -> CodebookArtifact:
+        return CodebookArtifact(
+            method="ORB",
+            trainer="minibatch_kmeans",
+            n_clusters=2,
+            descriptor_dim=32,
+            descriptor_dtype="uint8",
+            training_descriptor_count=2,
+            random_state=0,
+            batch_size=2,
+            cluster_centers=np.vstack([
+                np.zeros((1, 32), dtype=np.float32),
+                np.full((1, 32), 255.0, dtype=np.float32),
+            ]),
+        )
+
+    def _write_feature_npz(self, path: Path, method: str, descriptors: np.ndarray | None) -> Path:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        num_keypoints = 0 if descriptors is None else int(descriptors.shape[0])
+        keypoints = np.zeros((num_keypoints, 7), dtype=np.float32)
+        descriptors_present = descriptors is not None
+        descriptors_to_save = descriptors if descriptors is not None else np.empty((0, 0), dtype=np.float32)
+
+        np.savez_compressed(
+            path,
+            sample_id=np.array(path.stem),
+            method=np.array(method),
+            num_keypoints=np.array(num_keypoints, dtype=np.int32),
+            keypoints=keypoints,
+            descriptors=descriptors_to_save,
+            descriptors_present=np.array(int(descriptors_present), dtype=np.uint8),
+            descriptor_shape=np.array(() if descriptors is None else descriptors.shape, dtype=np.int32),
+            descriptor_dtype=np.array("" if descriptors is None else str(descriptors.dtype)),
+            keypoint_fields=np.array(("x", "y", "size", "angle", "response", "octave", "class_id")),
+        )
+        return path
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
What:
- normalize the `encoding` config shape around `input`, `codebook`, and `bow` while keeping Stage 4.3 field compatibility in script parsing
- add a minimal preview-time encoding hook in `scripts/run_pipeline.py` and a reusable single-file `encode_feature_file(...)` helper in `src/encoding/bow.py`
- add encoding usage docs, stage feedback, and focused integration tests for disabled preview, enabled preview, missing codebook, and offline batch compatibility

Why:
- integrate the existing Stage 4 encoding outputs into the current pipeline without changing default preview behavior
- keep offline batch encoding as the main full-dataset path while reusing the same config semantics and BoW interfaces
- prepare a clean handoff to TF-IDF and indexing by making encoding entrypoints stable, explicit, and method-aware